### PR TITLE
Multi-repo notifications and remove slash commands

### DIFF
--- a/discord-bot/bot.py
+++ b/discord-bot/bot.py
@@ -6,7 +6,6 @@ import re
 import subprocess
 
 import discord
-from discord import app_commands
 from discord.ext import commands
 from aiohttp import web
 
@@ -19,7 +18,6 @@ GUILD_ID = int(os.environ.get("AGENT_DISCORD_GUILD_ID", "0"))
 ALLOWED_USERS = set(os.environ.get("AGENT_DISCORD_ALLOWED_USERS", "").split(",")) - {""}
 ALLOWED_ROLE = os.environ.get("AGENT_DISCORD_ALLOWED_ROLE", "")
 BOT_PORT = int(os.environ.get("AGENT_DISCORD_BOT_PORT", "8675"))
-REPO = os.environ.get("AGENT_DISPATCH_REPO", "")
 
 
 def sanitize_input(text: str) -> str:
@@ -27,15 +25,21 @@ def sanitize_input(text: str) -> str:
     return re.sub(r"[`$\\]", "", text)[:2000]
 
 
-def parse_custom_id(custom_id: str) -> tuple[str | None, int | None]:
-    """Parse 'action:issue_number' from a button custom_id."""
-    if ":" not in custom_id:
-        return None, None
-    action, num_str = custom_id.split(":", 1)
+def parse_custom_id(custom_id: str) -> tuple[str | None, str | None, int | None]:
+    """Parse 'action:owner/repo:issue_number' from a button custom_id.
+
+    Returns (action, repo, issue_number) or (None, None, None) on failure.
+    """
+    parts = custom_id.split(":")
+    if len(parts) < 3:
+        return None, None, None
+    action = parts[0]
+    num_str = parts[-1]
+    repo = ":".join(parts[1:-1])
     try:
-        return action, int(num_str)
+        return action, repo, int(num_str)
     except ValueError:
-        return None, None
+        return None, None, None
 
 
 def is_authorized_check(
@@ -98,24 +102,24 @@ def build_embed(
     return embed
 
 
-def build_buttons(event_type: str, issue_number: int, url: str) -> discord.ui.View:
+def build_buttons(event_type: str, issue_number: int, url: str, repo: str) -> discord.ui.View:
     """Build interactive buttons for a notification message."""
     view = discord.ui.View(timeout=None)
     view.add_item(discord.ui.Button(label="View", url=url, style=discord.ButtonStyle.link))
 
     if event_type in _PLAN_EVENTS:
         view.add_item(discord.ui.Button(
-            label="Approve", custom_id=f"approve:{issue_number}", style=discord.ButtonStyle.success
+            label="Approve", custom_id=f"approve:{repo}:{issue_number}", style=discord.ButtonStyle.success
         ))
         view.add_item(discord.ui.Button(
-            label="Request Changes", custom_id=f"changes:{issue_number}", style=discord.ButtonStyle.danger
+            label="Request Changes", custom_id=f"changes:{repo}:{issue_number}", style=discord.ButtonStyle.danger
         ))
         view.add_item(discord.ui.Button(
-            label="Comment", custom_id=f"comment:{issue_number}", style=discord.ButtonStyle.secondary
+            label="Comment", custom_id=f"comment:{repo}:{issue_number}", style=discord.ButtonStyle.secondary
         ))
     elif event_type in _RETRY_EVENTS:
         view.add_item(discord.ui.Button(
-            label="Retry", custom_id=f"retry:{issue_number}", style=discord.ButtonStyle.primary
+            label="Retry", custom_id=f"retry:{repo}:{issue_number}", style=discord.ButtonStyle.primary
         ))
 
     return view
@@ -190,14 +194,14 @@ class FeedbackModal(discord.ui.Modal):
 
         gh_dispatch(self.repo, "agent-reply", self.issue_number)
         await interaction.followup.send("Feedback posted to GitHub.", ephemeral=True)
-        log.info("MODAL: %s on #%d by %s (id=%s)", self.action, self.issue_number, interaction.user, interaction.user.id)
+        log.info("MODAL: %s on %s#%d by %s (id=%s)", self.action, self.repo, self.issue_number, interaction.user, interaction.user.id)
 
 
 async def handle_button_interaction(interaction: discord.Interaction) -> None:
     """Handle a button click on a notification message."""
     custom_id = interaction.data.get("custom_id", "")
-    action, issue_number = parse_custom_id(custom_id)
-    if action is None or issue_number is None:
+    action, repo, issue_number = parse_custom_id(custom_id)
+    if action is None or repo is None or issue_number is None:
         return
 
     user_id = str(interaction.user.id)
@@ -210,7 +214,7 @@ async def handle_button_interaction(interaction: discord.Interaction) -> None:
         return
 
     if action in ("changes", "comment"):
-        modal = FeedbackModal(action=action, issue_number=issue_number, repo=REPO)
+        modal = FeedbackModal(action=action, issue_number=issue_number, repo=repo)
         await interaction.response.send_modal(modal)
         return
 
@@ -218,13 +222,13 @@ async def handle_button_interaction(interaction: discord.Interaction) -> None:
 
     if action == "approve":
         ok, err = gh_command([
-            "issue", "edit", str(issue_number), "--repo", REPO,
+            "issue", "edit", str(issue_number), "--repo", repo,
             "--remove-label", "agent:plan-review", "--add-label", "agent:plan-approved",
         ])
         status_text = f"Approved by {interaction.user.display_name}"
     elif action == "retry":
         ok, err = gh_command([
-            "issue", "edit", str(issue_number), "--repo", REPO,
+            "issue", "edit", str(issue_number), "--repo", repo,
             "--remove-label", ",".join(_ALL_AGENT_LABELS), "--add-label", "agent",
         ])
         status_text = f"Retried by {interaction.user.display_name}"
@@ -240,7 +244,7 @@ async def handle_button_interaction(interaction: discord.Interaction) -> None:
 
     # Map button actions to dispatch event types
     dispatch_events = {"approve": "agent-implement", "retry": "agent-triage"}
-    dispatch_ok, dispatch_err = gh_dispatch(REPO, dispatch_events[action], issue_number)
+    dispatch_ok, dispatch_err = gh_dispatch(repo, dispatch_events[action], issue_number)
 
     embed = interaction.message.embeds[0] if interaction.message.embeds else discord.Embed()
     embed.add_field(name="Action", value=status_text, inline=False)
@@ -258,98 +262,7 @@ async def handle_button_interaction(interaction: discord.Interaction) -> None:
         )
     else:
         await interaction.followup.send(f"Done: {status_text}", ephemeral=True)
-    log.info("ACTION: %s on #%d by %s (id=%s)", action, issue_number, interaction.user, interaction.user.id)
-
-
-def register_slash_commands(tree: app_commands.CommandTree) -> None:
-    """Register all slash commands on the command tree."""
-
-    @tree.command(name="approve", description="Approve an agent's plan")
-    @app_commands.describe(issue="Issue number")
-    async def cmd_approve(interaction: discord.Interaction, issue: int):
-        if not _check_slash_auth(interaction):
-            return await interaction.response.send_message("Permission denied.", ephemeral=True)
-        await interaction.response.defer(ephemeral=True)
-        ok, err = gh_command([
-            "issue", "edit", str(issue), "--repo", REPO,
-            "--remove-label", "agent:plan-review", "--add-label", "agent:plan-approved",
-        ])
-        if not ok:
-            await interaction.followup.send(f"Failed to update #{issue}: {err}", ephemeral=True)
-            return
-        gh_dispatch(REPO, "agent-implement", issue)
-        await interaction.followup.send(f"Plan for #{issue} approved.", ephemeral=True)
-        log.info("SLASH: /approve #%d by %s", issue, interaction.user)
-
-    @tree.command(name="reject", description="Reject a plan with reason")
-    @app_commands.describe(issue="Issue number", reason="Reason for rejection")
-    async def cmd_reject(interaction: discord.Interaction, issue: int, reason: str = ""):
-        if not _check_slash_auth(interaction):
-            return await interaction.response.send_message("Permission denied.", ephemeral=True)
-        await interaction.response.defer(ephemeral=True)
-        body = sanitize_input(reason) if reason else "Plan rejected via Discord."
-        ok, err = gh_command(["issue", "comment", str(issue), "--repo", REPO, "--body", body])
-        if not ok:
-            await interaction.followup.send(f"Failed to comment on #{issue}: {err}", ephemeral=True)
-            return
-        ok, err = gh_command(["issue", "edit", str(issue), "--repo", REPO, "--add-label", "agent:failed"])
-        if not ok:
-            await interaction.followup.send(f"Failed to label #{issue}: {err}", ephemeral=True)
-            return
-        await interaction.followup.send(f"Plan for #{issue} rejected.", ephemeral=True)
-        log.info("SLASH: /reject #%d by %s", issue, interaction.user)
-
-    @tree.command(name="comment", description="Post feedback on an issue")
-    @app_commands.describe(issue="Issue number", text="Your comment")
-    async def cmd_comment(interaction: discord.Interaction, issue: int, text: str):
-        if not _check_slash_auth(interaction):
-            return await interaction.response.send_message("Permission denied.", ephemeral=True)
-        await interaction.response.defer(ephemeral=True)
-        ok, err = gh_command(["issue", "comment", str(issue), "--repo", REPO, "--body", sanitize_input(text)])
-        if not ok:
-            await interaction.followup.send(f"Failed to comment on #{issue}: {err}", ephemeral=True)
-            return
-        gh_dispatch(REPO, "agent-reply", issue)
-        await interaction.followup.send(f"Comment posted on #{issue}.", ephemeral=True)
-        log.info("SLASH: /comment #%d by %s", issue, interaction.user)
-
-    @tree.command(name="status", description="Check agent status for an issue")
-    @app_commands.describe(issue="Issue number")
-    async def cmd_status(interaction: discord.Interaction, issue: int):
-        if not _check_slash_auth(interaction):
-            return await interaction.response.send_message("Permission denied.", ephemeral=True)
-        await interaction.response.defer(ephemeral=True)
-        ok, output = gh_command(["issue", "view", str(issue), "--repo", REPO, "--json", "labels", "--jq", ".labels[].name"])
-        if not ok:
-            await interaction.followup.send(f"Failed to fetch #{issue}: {output}", ephemeral=True)
-            return
-        agent_labels = [l for l in output.split("\n") if l.startswith("agent")]
-        status = ", ".join(agent_labels) if agent_labels else "No agent labels"
-        await interaction.followup.send(f"#{issue} status: {status}", ephemeral=True)
-
-    @tree.command(name="retry", description="Re-trigger agent on an issue")
-    @app_commands.describe(issue="Issue number")
-    async def cmd_retry(interaction: discord.Interaction, issue: int):
-        if not _check_slash_auth(interaction):
-            return await interaction.response.send_message("Permission denied.", ephemeral=True)
-        await interaction.response.defer(ephemeral=True)
-        ok, err = gh_command([
-            "issue", "edit", str(issue), "--repo", REPO,
-            "--remove-label", ",".join(_ALL_AGENT_LABELS), "--add-label", "agent",
-        ])
-        if not ok:
-            await interaction.followup.send(f"Failed to update #{issue}: {err}", ephemeral=True)
-            return
-        gh_dispatch(REPO, "agent-triage", issue)
-        await interaction.followup.send(f"Agent re-triggered on #{issue}.", ephemeral=True)
-        log.info("SLASH: /retry #%d by %s", issue, interaction.user)
-
-
-def _check_slash_auth(interaction: discord.Interaction) -> bool:
-    """Authorization check for slash commands."""
-    user_id = str(interaction.user.id)
-    role_ids = [str(r.id) for r in getattr(interaction.user, "roles", [])]
-    return is_authorized_check(user_id, role_ids, ALLOWED_USERS, ALLOWED_ROLE)
+    log.info("ACTION: %s on %s#%d by %s (id=%s)", action, repo, issue_number, interaction.user, interaction.user.id)
 
 
 def create_notify_handler(channel):
@@ -367,7 +280,7 @@ def create_notify_handler(channel):
         repo = data.get("repo", "")
 
         embed = build_embed(event_type, title, url, description, issue_number, repo)
-        view = build_buttons(event_type, issue_number, url)
+        view = build_buttons(event_type, issue_number, url, repo)
         await channel.send(embed=embed, view=view)
         return web.Response(text="OK")
 
@@ -397,19 +310,12 @@ def main() -> None:
     if not GUILD_ID:
         print("Error: AGENT_DISCORD_GUILD_ID is not set")
         raise SystemExit(1)
-    if not REPO:
-        print("Error: AGENT_DISPATCH_REPO is not set (e.g., 'owner/repo')")
-        raise SystemExit(1)
 
     intents = discord.Intents.default()
     bot = commands.Bot(command_prefix="!", intents=intents)
-    register_slash_commands(bot.tree)
 
     @bot.event
     async def on_ready():
-        guild = discord.Object(id=GUILD_ID)
-        bot.tree.copy_global_to(guild=guild)
-        await bot.tree.sync(guild=guild)
         log.info("Bot ready: %s (guild %d)", bot.user, GUILD_ID)
 
         channel = bot.get_channel(CHANNEL_ID)
@@ -419,8 +325,6 @@ def main() -> None:
 
     @bot.event
     async def on_interaction(interaction: discord.Interaction):
-        # commands.Bot handles slash commands automatically via its tree.
-        # We only need to handle button clicks here.
         if interaction.type == discord.InteractionType.component:
             await handle_button_interaction(interaction)
 

--- a/discord-bot/tests/test_embeds.py
+++ b/discord-bot/tests/test_embeds.py
@@ -45,46 +45,46 @@ class TestBuildEmbed:
 
 class TestBuildButtons:
     def test_plan_posted_has_approve_changes_comment(self):
-        view = build_buttons("plan_posted", 42, "https://example.com")
+        view = build_buttons("plan_posted", 42, "https://example.com", "org/repo")
         labels = [child.label for child in view.children]
         assert "Approve" in labels
         assert "Request Changes" in labels
         assert "Comment" in labels
 
     def test_plan_posted_has_view_link(self):
-        view = build_buttons("plan_posted", 42, "https://example.com")
+        view = build_buttons("plan_posted", 42, "https://example.com", "org/repo")
         link_buttons = [c for c in view.children if c.url]
         assert len(link_buttons) >= 1
         assert link_buttons[0].url == "https://example.com"
 
     def test_agent_failed_has_retry(self):
-        view = build_buttons("agent_failed", 42, "https://example.com")
+        view = build_buttons("agent_failed", 42, "https://example.com", "org/repo")
         labels = [child.label for child in view.children]
         assert "Retry" in labels
 
     def test_agent_failed_no_approve(self):
-        view = build_buttons("agent_failed", 42, "https://example.com")
+        view = build_buttons("agent_failed", 42, "https://example.com", "org/repo")
         labels = [child.label for child in view.children]
         assert "Approve" not in labels
 
     def test_tests_passed_view_only(self):
-        view = build_buttons("tests_passed", 42, "https://example.com")
+        view = build_buttons("tests_passed", 42, "https://example.com", "org/repo")
         action_buttons = [c for c in view.children if not c.url]
         assert len(action_buttons) == 0
 
-    def test_custom_ids_encode_issue_number(self):
-        view = build_buttons("plan_posted", 99, "https://example.com")
+    def test_custom_ids_encode_repo_and_issue(self):
+        view = build_buttons("plan_posted", 99, "https://example.com", "org/repo")
         custom_ids = [c.custom_id for c in view.children if c.custom_id]
-        assert "approve:99" in custom_ids
-        assert "changes:99" in custom_ids
-        assert "comment:99" in custom_ids
+        assert "approve:org/repo:99" in custom_ids
+        assert "changes:org/repo:99" in custom_ids
+        assert "comment:org/repo:99" in custom_ids
 
     def test_review_feedback_has_view_only(self):
-        view = build_buttons("review_feedback", 42, "https://example.com")
+        view = build_buttons("review_feedback", 42, "https://example.com", "org/repo")
         action_buttons = [c for c in view.children if not c.url]
         assert len(action_buttons) == 0
 
     def test_pr_created_has_view_link(self):
-        view = build_buttons("pr_created", 42, "https://example.com/pull/5")
+        view = build_buttons("pr_created", 42, "https://example.com/pull/5", "org/repo")
         link_buttons = [c for c in view.children if c.url]
         assert any(b.url == "https://example.com/pull/5" for b in link_buttons)

--- a/discord-bot/tests/test_http.py
+++ b/discord-bot/tests/test_http.py
@@ -63,6 +63,17 @@ class TestNotifyHandler:
         assert len(view.children) > 1  # View link + action buttons
 
     @pytest.mark.asyncio
+    async def test_buttons_contain_repo_in_custom_id(self, handler, mock_channel, make_request):
+        request = make_request(VALID_PAYLOAD)
+        await handler(request)
+        call_kwargs = mock_channel.send.call_args
+        view = call_kwargs.kwargs["view"]
+        action_buttons = [b for b in view.children if hasattr(b, "custom_id") and b.custom_id]
+        assert len(action_buttons) > 0
+        for button in action_buttons:
+            assert "org/repo" in button.custom_id
+
+    @pytest.mark.asyncio
     async def test_returns_503_when_channel_is_none(self, make_request):
         handler = create_notify_handler(None)
         request = make_request(VALID_PAYLOAD)

--- a/discord-bot/tests/test_interactions.py
+++ b/discord-bot/tests/test_interactions.py
@@ -8,10 +8,43 @@ from bot import (
     gh_command,
     gh_dispatch,
     handle_button_interaction,
+    parse_custom_id,
     FeedbackModal,
     ALLOWED_USERS,
     ALLOWED_ROLE,
 )
+
+
+class TestParseCustomId:
+    def test_parses_action_repo_issue(self):
+        action, repo, issue = parse_custom_id("approve:org/repo:42")
+        assert action == "approve"
+        assert repo == "org/repo"
+        assert issue == 42
+
+    def test_parses_repo_with_hyphens(self):
+        action, repo, issue = parse_custom_id("retry:Frightful-Games/recipe-manager-demo:7")
+        assert action == "retry"
+        assert repo == "Frightful-Games/recipe-manager-demo"
+        assert issue == 7
+
+    def test_returns_none_for_old_format(self):
+        action, repo, issue = parse_custom_id("approve:42")
+        assert action is None
+        assert repo is None
+        assert issue is None
+
+    def test_returns_none_for_no_colon(self):
+        action, repo, issue = parse_custom_id("approve")
+        assert action is None
+        assert repo is None
+        assert issue is None
+
+    def test_returns_none_for_non_numeric_issue(self):
+        action, repo, issue = parse_custom_id("approve:org/repo:abc")
+        assert action is None
+        assert repo is None
+        assert issue is None
 
 
 class TestGhCommand:
@@ -70,8 +103,8 @@ class TestHandleButtonInteraction:
     async def test_approve_adds_label(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (True, "")
         mock_dispatch.return_value = (True, "")
-        interaction = _mock_interaction("approve:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("approve:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         calls = [str(c) for c in mock_gh.call_args_list]
         combined = " ".join(calls)
@@ -80,11 +113,23 @@ class TestHandleButtonInteraction:
     @patch("bot.gh_dispatch")
     @patch("bot.gh_command")
     @pytest.mark.asyncio
+    async def test_approve_uses_repo_from_custom_id(self, mock_gh, mock_dispatch):
+        mock_gh.return_value = (True, "")
+        mock_dispatch.return_value = (True, "")
+        interaction = _mock_interaction("approve:Frightful-Games/recipe-manager-demo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
+            await handle_button_interaction(interaction)
+        gh_args = mock_gh.call_args[0][0]
+        assert "Frightful-Games/recipe-manager-demo" in gh_args
+
+    @patch("bot.gh_dispatch")
+    @patch("bot.gh_command")
+    @pytest.mark.asyncio
     async def test_approve_sends_ephemeral_confirmation(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (True, "")
         mock_dispatch.return_value = (True, "")
-        interaction = _mock_interaction("approve:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("approve:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         interaction.followup.send.assert_called_once()
 
@@ -94,8 +139,8 @@ class TestHandleButtonInteraction:
     async def test_approve_failure_reports_error(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (False, "gh auth login required")
         mock_dispatch.return_value = (True, "")
-        interaction = _mock_interaction("approve:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("approve:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         interaction.followup.send.assert_called_once()
         msg = interaction.followup.send.call_args[0][0]
@@ -105,7 +150,7 @@ class TestHandleButtonInteraction:
 
     @pytest.mark.asyncio
     async def test_unauthorized_user_rejected(self):
-        interaction = _mock_interaction("approve:42", user_id="999")
+        interaction = _mock_interaction("approve:org/repo:42", user_id="999")
         with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.ALLOWED_ROLE", ""):
             await handle_button_interaction(interaction)
         interaction.response.send_message.assert_called_once()
@@ -118,8 +163,8 @@ class TestHandleButtonInteraction:
     async def test_retry_resets_labels(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (True, "")
         mock_dispatch.return_value = (True, "")
-        interaction = _mock_interaction("retry:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("retry:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         mock_gh.assert_called_once()
         call_args = mock_gh.call_args[0][0]
@@ -133,8 +178,8 @@ class TestHandleButtonInteraction:
     async def test_approve_fires_dispatch(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (True, "")
         mock_dispatch.return_value = (True, "")
-        interaction = _mock_interaction("approve:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("approve:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         mock_dispatch.assert_called_once_with("org/repo", "agent-implement", 42)
 
@@ -144,8 +189,8 @@ class TestHandleButtonInteraction:
     async def test_retry_fires_dispatch(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (True, "")
         mock_dispatch.return_value = (True, "")
-        interaction = _mock_interaction("retry:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("retry:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         mock_dispatch.assert_called_once_with("org/repo", "agent-triage", 42)
 
@@ -155,8 +200,8 @@ class TestHandleButtonInteraction:
     async def test_dispatch_failure_still_shows_success(self, mock_gh, mock_dispatch):
         mock_gh.return_value = (True, "")
         mock_dispatch.return_value = (False, "dispatch failed")
-        interaction = _mock_interaction("approve:42", user_id="123")
-        with patch("bot.ALLOWED_USERS", {"123"}), patch("bot.REPO", "org/repo"):
+        interaction = _mock_interaction("approve:org/repo:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         # Label succeeded, so Discord UI should still update
         interaction.message.edit.assert_called_once()
@@ -166,17 +211,27 @@ class TestHandleButtonInteraction:
 
     @pytest.mark.asyncio
     async def test_changes_shows_modal(self):
-        interaction = _mock_interaction("changes:42", user_id="123")
+        interaction = _mock_interaction("changes:org/repo:42", user_id="123")
         with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         interaction.response.send_modal.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_comment_shows_modal(self):
-        interaction = _mock_interaction("comment:42", user_id="123")
+        interaction = _mock_interaction("comment:org/repo:42", user_id="123")
         with patch("bot.ALLOWED_USERS", {"123"}):
             await handle_button_interaction(interaction)
         interaction.response.send_modal.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ignores_invalid_custom_id(self):
+        interaction = _mock_interaction("approve:42", user_id="123")
+        with patch("bot.ALLOWED_USERS", {"123"}):
+            await handle_button_interaction(interaction)
+        # Should silently return without any response
+        interaction.response.defer.assert_not_called()
+        interaction.response.send_message.assert_not_called()
+        interaction.response.send_modal.assert_not_called()
 
 
 class TestGhDispatch:

--- a/discord-bot/tests/test_utils.py
+++ b/discord-bot/tests/test_utils.py
@@ -33,33 +33,39 @@ class TestSanitizeInput:
 
 class TestParseCustomId:
     def test_approve(self):
-        action, issue = parse_custom_id("approve:42")
+        action, repo, issue = parse_custom_id("approve:org/repo:42")
         assert action == "approve"
+        assert repo == "org/repo"
         assert issue == 42
 
     def test_changes(self):
-        action, issue = parse_custom_id("changes:7")
+        action, repo, issue = parse_custom_id("changes:org/repo:7")
         assert action == "changes"
+        assert repo == "org/repo"
         assert issue == 7
 
     def test_comment(self):
-        action, issue = parse_custom_id("comment:123")
+        action, repo, issue = parse_custom_id("comment:org/repo:123")
         assert action == "comment"
+        assert repo == "org/repo"
         assert issue == 123
 
     def test_retry(self):
-        action, issue = parse_custom_id("retry:1")
+        action, repo, issue = parse_custom_id("retry:org/repo:1")
         assert action == "retry"
+        assert repo == "org/repo"
         assert issue == 1
 
     def test_invalid_no_colon(self):
-        action, issue = parse_custom_id("invalid")
+        action, repo, issue = parse_custom_id("invalid")
         assert action is None
+        assert repo is None
         assert issue is None
 
     def test_invalid_non_numeric(self):
-        action, issue = parse_custom_id("approve:abc")
+        action, repo, issue = parse_custom_id("approve:org/repo:abc")
         assert action is None
+        assert repo is None
         assert issue is None
 
 


### PR DESCRIPTION
 ## Summary

  - Embed repo in button `custom_id` (`action:owner/repo:issue`) so the bot handles notifications from any repo without
  restart
  - Parse repo from button interactions and pass dynamically to all `gh` CLI calls
  - Pass `repo` from notification payload through to `build_buttons()`
  - Remove `AGENT_DISPATCH_REPO` startup requirement (no longer needed)
  - Remove all slash commands (`/approve`, `/reject`, `/comment`, `/status`, `/retry`) — buttons provide the same
  functionality with repo context built-in
  - Remove `app_commands` and command tree registration

  ## Test plan
  - [x] All 71 existing tests pass (updated for new custom_id format)
  - [x] New test: `test_approve_uses_repo_from_custom_id` — verifies repo flows from button to gh command
  - [x] New test: `test_buttons_contain_repo_in_custom_id` — verifies notification handler embeds repo
  - [x] New test: `test_ignores_invalid_custom_id` — verifies old-format buttons are silently ignored
  - [ ] Deploy and verify with live notifications from multiple repos