### PR TITLE
Layered config

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -49,7 +49,7 @@ Use the `AskUserQuestion` tool to collect the following. If the user provided an
 ## Step 3: Generate Configuration
 
 ### Reference mode
-Read the template at `config.env.example` (in the repo root). Fill in the user's answers and write to `config.env` in the repo root. Show the user the generated config and ask if they want to adjust anything.
+Read the template at `config.defaults.env.example` (in the repo root). Fill in the user's answers and write to `config.env` in the repo root (reference mode uses a single file since it's not committed to a repo). Show the user the generated config and ask if they want to adjust anything.
 
 ### Standalone mode
 Create the `.agent-dispatch/` directory in the user's target repo. Copy:
@@ -58,7 +58,12 @@ Create the `.agent-dispatch/` directory in the user's target repo. Copy:
 - `scripts/check-prereqs.sh` and `scripts/create-labels.sh` → `.agent-dispatch/scripts/`
 - `prompts/*.md` → `.agent-dispatch/prompts/`
 - `labels.txt` → `.agent-dispatch/`
-- Generated `config.env` → `.agent-dispatch/config.env`
+- Generated `config.defaults.env` → `.agent-dispatch/config.defaults.env` (non-sensitive project config, committed)
+
+**Important:** Configuration uses a layered approach:
+- `config.defaults.env` — **committed** to the repo. Contains non-sensitive project config (bot username, timeouts, tool permissions, test commands). This file MUST NOT contain secrets, tokens, or credentials.
+- `config.env` — **gitignored**, optional. Contains sensitive overrides (Discord tokens, webhook URLs, GitHub tokens). Values here override `config.defaults.env`.
+- Environment variables — highest precedence, override both files.
 
 Make all scripts executable after copying.
 

--- a/.claude/skills/setup/templates/standalone/agent-dispatch.yml
+++ b/.claude/skills/setup/templates/standalone/agent-dispatch.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             new_issue \
@@ -48,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             implement \
@@ -71,7 +71,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             issue_reply \

--- a/.claude/skills/setup/templates/standalone/agent-implement.yml
+++ b/.claude/skills/setup/templates/standalone/agent-implement.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             implement \

--- a/.claude/skills/setup/templates/standalone/agent-reply.yml
+++ b/.claude/skills/setup/templates/standalone/agent-reply.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             issue_reply \

--- a/.claude/skills/setup/templates/standalone/agent-review.yml
+++ b/.claude/skills/setup/templates/standalone/agent-review.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             pr_review \

--- a/.claude/skills/setup/templates/standalone/agent-triage.yml
+++ b/.claude/skills/setup/templates/standalone/agent-triage.yml
@@ -27,7 +27,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.AGENT_PAT }}
           GITHUB_TOKEN: ${{ secrets.AGENT_PAT }}
-          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env
+          AGENT_CONFIG: ${{ github.workspace }}/.agent-dispatch/config.env  # override file (gitignored, optional)
         run: |
           .agent-dispatch/scripts/agent-dispatch.sh \
             new_issue \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ Run `/setup` to configure this toolkit for your project.
 - `scripts/lib/` — Modular functions: logging, labels, worktrees, data fetching, defaults
 - `prompts/` — Default agent prompts (triage, implement, reply, review)
 - `.github/workflows/dispatch-*.yml` — Reusable workflows called by consuming repos
-- `config.env` — Project-specific configuration (not committed, see `config.env.example`)
+- `config.defaults.env` — Project defaults, committed (see `config.defaults.env.example`)
+- `config.env` — Sensitive overrides, gitignored (see `config.env.example`)
 
 ## Development
 

--- a/config.defaults.env.example
+++ b/config.defaults.env.example
@@ -1,0 +1,62 @@
+# ╔══════════════════════════════════════════════════════════════╗
+# ║  Claude Agent Dispatch — Project Defaults                  ║
+# ║  Copy to .agent-dispatch/config.defaults.env (standalone)  ║
+# ║  or ~/agent-infra/config.defaults.env (reference mode)     ║
+# ║                                                            ║
+# ║  ⚠  This file is COMMITTED to the repository.              ║
+# ║     Do NOT put secrets, tokens, or credentials here.       ║
+# ║     Use config.env for sensitive overrides (gitignored).   ║
+# ╚══════════════════════════════════════════════════════════════╝
+
+# ── Required ─────────────────────────────────────────────────
+# GitHub bot account username (the account that will comment, push, create PRs)
+AGENT_BOT_USER=""
+
+# ── Optional (defaults shown) ────────────────────────────────
+# Max Claude conversation turns per invocation
+AGENT_MAX_TURNS=200
+
+# Timeout in seconds before killing a stuck claude -p process
+AGENT_TIMEOUT=3600
+
+# Circuit breaker: max bot comments per hour per issue
+AGENT_CIRCUIT_BREAKER_LIMIT=8
+
+# Path to shared Claude memory file (optional, enhances agent context)
+# AGENT_MEMORY_FILE=""
+
+# Pre-PR test command (if set, tests must pass before PR creation)
+# Examples:
+# AGENT_TEST_COMMAND="npm test"
+# AGENT_TEST_COMMAND="pytest"
+# AGENT_TEST_COMMAND="cargo test"
+# AGENT_TEST_COMMAND="dotnet test"
+
+# ── Tool Permissions ─────────────────────────────────────────
+# Claude tools allowed during triage/reply (read-only by default)
+AGENT_ALLOWED_TOOLS_TRIAGE="Read,Grep,Glob,Bash(echo:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"
+
+# Claude tools allowed during implementation/review (read-write by default)
+AGENT_ALLOWED_TOOLS_IMPLEMENT="Read,Edit,Write,Grep,Glob,Bash(git add:*),Bash(git commit:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(find:*),Bash(mkdir:*)"
+
+# Additional tools to append for project-specific needs
+# Examples:
+# AGENT_EXTRA_TOOLS="Bash(npm:*),Bash(npx:*)"
+# AGENT_EXTRA_TOOLS="Bash(cargo:*)"
+# AGENT_EXTRA_TOOLS="Bash(dotnet:*)"
+# AGENT_EXTRA_TOOLS="Bash(Godot:*),Bash(godot:*)"
+
+# ── Custom Prompts (optional, uses built-in defaults if unset) ──
+# Point to your own prompt files to customize agent behavior
+# AGENT_PROMPT_TRIAGE="/path/to/your/triage-prompt.md"
+# AGENT_PROMPT_IMPLEMENT="/path/to/your/implement-prompt.md"
+# AGENT_PROMPT_REPLY="/path/to/your/reply-prompt.md"
+# AGENT_PROMPT_REVIEW="/path/to/your/review-prompt.md"
+
+# ── Notifications ────────────────────────────────────────────
+# Notification level: "all" (every milestone), "actionable" (default, events
+# needing user response), "failures" (only failures)
+# AGENT_NOTIFY_LEVEL="actionable"
+
+# Backend: "webhook" (Phase 1, default) or "bot" (Phase 2, interactive)
+# AGENT_NOTIFY_BACKEND="webhook"

--- a/config.env.example
+++ b/config.env.example
@@ -1,54 +1,14 @@
 # ╔══════════════════════════════════════════════════════════════╗
-# ║  Claude Agent Dispatch — Project Configuration              ║
-# ║  Copy this file to config.env and fill in your values       ║
+# ║  Claude Agent Dispatch — Sensitive Overrides               ║
+# ║  Copy to .agent-dispatch/config.env (standalone)           ║
+# ║  or ~/agent-infra/config.env (reference mode)              ║
+# ║                                                            ║
+# ║  ⚠  This file is GITIGNORED — do NOT commit it.            ║
+# ║     It contains secrets and credentials.                   ║
+# ║     Values here override config.defaults.env.              ║
 # ╚══════════════════════════════════════════════════════════════╝
 
-# ── Required ─────────────────────────────────────────────────
-# GitHub bot account username (the account that will comment, push, create PRs)
-AGENT_BOT_USER=""
-
-# ── Optional (defaults shown) ────────────────────────────────
-# Max Claude conversation turns per invocation
-AGENT_MAX_TURNS=200
-
-# Timeout in seconds before killing a stuck claude -p process
-AGENT_TIMEOUT=3600
-
-# Circuit breaker: max bot comments per hour per issue
-AGENT_CIRCUIT_BREAKER_LIMIT=8
-
-# Path to shared Claude memory file (optional, enhances agent context)
-# AGENT_MEMORY_FILE=""
-
-# Pre-PR test command (if set, tests must pass before PR creation)
-# Examples:
-# AGENT_TEST_COMMAND="npm test"
-# AGENT_TEST_COMMAND="pytest"
-# AGENT_TEST_COMMAND="cargo test"
-# AGENT_TEST_COMMAND="go test ./..."
-# AGENT_TEST_COMMAND="godot --headless --path . -s addons/gdUnit4/bin/GdUnitCmdTool.gd --add res://tests/unit --ignoreHeadlessMode"
-
-# ── Tool Permissions ─────────────────────────────────────────
-# Claude tools allowed during triage/reply (read-only by default)
-AGENT_ALLOWED_TOOLS_TRIAGE="Read,Grep,Glob,Bash(echo:*),Bash(cat:*),Bash(ls:*),Bash(find:*)"
-
-# Claude tools allowed during implementation/review (read-write by default)
-AGENT_ALLOWED_TOOLS_IMPLEMENT="Read,Edit,Write,Grep,Glob,Bash(git add:*),Bash(git commit:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(find:*),Bash(mkdir:*)"
-
-# Additional tools to append for project-specific needs
-# Examples:
-# AGENT_EXTRA_TOOLS="Bash(npm:*),Bash(npx:*)"
-# AGENT_EXTRA_TOOLS="Bash(cargo:*)"
-# AGENT_EXTRA_TOOLS="Bash(Godot:*),Bash(godot:*),Bash(curl *localhost:8188*)"
-
-# ── Custom Prompts (optional, uses built-in defaults if unset) ──
-# Point to your own prompt files to customize agent behavior
-# AGENT_PROMPT_TRIAGE="/path/to/your/triage-prompt.md"
-# AGENT_PROMPT_IMPLEMENT="/path/to/your/implement-prompt.md"
-# AGENT_PROMPT_REPLY="/path/to/your/reply-prompt.md"
-# AGENT_PROMPT_REVIEW="/path/to/your/review-prompt.md"
-
-# ── Notifications (optional, disabled by default) ────────────────
+# ── Notification Secrets ─────────────────────────────────────
 # Discord webhook URL — set to enable agent milestone notifications
 # Create one: Server Settings > Integrations > Webhooks > New Webhook
 # AGENT_NOTIFY_DISCORD_WEBHOOK="https://discord.com/api/webhooks/ID/TOKEN"
@@ -56,14 +16,8 @@ AGENT_ALLOWED_TOOLS_IMPLEMENT="Read,Edit,Write,Grep,Glob,Bash(git add:*),Bash(gi
 # Optional: post notifications to a specific Discord thread
 # AGENT_NOTIFY_DISCORD_THREAD_ID=""
 
-# Notification level: "all" (every milestone), "actionable" (default, events
-# needing user response), "failures" (only failures)
-# AGENT_NOTIFY_LEVEL="actionable"
-
-# ── Discord Bot (Phase 2 — interactive notifications) ────────────
-# Enables buttons, slash commands, and modals for two-way interaction.
-# Set AGENT_NOTIFY_BACKEND="bot" to activate. Requires a Discord bot application.
-# See discord-bot/README.md for setup instructions.
+# ── Discord Bot (interactive notifications) ──────────────────
+# Requires a Discord bot application. See discord-bot/README.md for setup.
 
 # Discord bot token (from Discord Developer Portal > Bot > Token)
 # AGENT_DISCORD_BOT_TOKEN=""
@@ -71,7 +25,7 @@ AGENT_ALLOWED_TOOLS_IMPLEMENT="Read,Edit,Write,Grep,Glob,Bash(git add:*),Bash(gi
 # Discord channel ID for notifications (right-click channel > Copy Channel ID)
 # AGENT_DISCORD_CHANNEL_ID=""
 
-# Discord guild (server) ID for slash command registration
+# Discord guild (server) ID
 # AGENT_DISCORD_GUILD_ID=""
 
 # Comma-separated Discord user IDs allowed to click action buttons
@@ -83,9 +37,12 @@ AGENT_ALLOWED_TOOLS_IMPLEMENT="Read,Edit,Write,Grep,Glob,Bash(git add:*),Bash(gi
 # Local HTTP port for dispatch -> bot communication (default: 8675)
 # AGENT_DISCORD_BOT_PORT="8675"
 
-# Backend: "webhook" (Phase 1, default) or "bot" (Phase 2, interactive)
-# AGENT_NOTIFY_BACKEND="webhook"
-
-# GitHub repository for the bot to operate on (owner/repo format)
-# Required when AGENT_NOTIFY_BACKEND="bot" — used for gh CLI calls from Discord
-# AGENT_DISPATCH_REPO="owner/repo"
+# ── Environment Overrides ────────────────────────────────────
+# Override any value from config.defaults.env here.
+# Any variable set in this file takes precedence over defaults.
+#
+# Example: override the bot user for a different environment
+# AGENT_BOT_USER="my-other-bot"
+#
+# Example: use a repo-specific GitHub token (see issue #4)
+# GH_TOKEN="ghp_xxxxxxxxxxxx"

--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -19,17 +19,38 @@ REPO="${2:?}"
 NUMBER="${3:?}"  # Issue or PR number
 
 # ─── Load configuration ─────────────────────────────────────────
-# Source project-specific config if it exists
-AGENT_CONFIG="${AGENT_CONFIG:-$HOME/agent-infra/config.env}"
-if [ -f "$AGENT_CONFIG" ]; then
+# Layered config: defaults (committed) → overrides (gitignored) → defaults.sh
+#
+# 1. config.defaults.env — committed, non-sensitive project config
+# 2. config.env           — gitignored, optional sensitive overrides (GH_TOKEN, etc.)
+# 3. defaults.sh          — fills in anything still unset
+#
+# Environment variables always take highest precedence.
+
+# Source committed defaults first (standalone mode: .agent-dispatch/config.defaults.env)
+AGENT_DEFAULTS="${SCRIPT_DIR}/../config.defaults.env"
+if [ -f "$AGENT_DEFAULTS" ]; then
     # shellcheck source=/dev/null
-    source "$AGENT_CONFIG"
-    # Resolve config directory for relative prompt paths
-    CONFIG_DIR="$(cd "$(dirname "$AGENT_CONFIG")" && pwd)"
+    source "$AGENT_DEFAULTS"
+    CONFIG_DIR="$(cd "$(dirname "$AGENT_DEFAULTS")" && pwd)"
     export CONFIG_DIR
 fi
 
-# Source defaults (fills in anything not set by config.env)
+# Source optional overrides (may contain secrets — never commit this file)
+AGENT_CONFIG="${AGENT_CONFIG:-}"
+if [ -n "$AGENT_CONFIG" ] && [ -f "$AGENT_CONFIG" ]; then
+    # shellcheck source=/dev/null
+    source "$AGENT_CONFIG"
+    CONFIG_DIR="$(cd "$(dirname "$AGENT_CONFIG")" && pwd)"
+    export CONFIG_DIR
+elif [ -f "${SCRIPT_DIR}/../config.env" ]; then
+    # shellcheck source=/dev/null
+    source "${SCRIPT_DIR}/../config.env"
+    CONFIG_DIR="$(cd "$(dirname "${SCRIPT_DIR}/../config.env")" && pwd)"
+    export CONFIG_DIR
+fi
+
+# Source defaults (fills in anything not set by either config file)
 # shellcheck source=lib/defaults.sh
 source "${SCRIPT_DIR}/lib/defaults.sh"
 


### PR DESCRIPTION
## Summary

  - Split config into two layers: `config.defaults.env` (committed, non-sensitive) and `config.env` (gitignored,
  sensitive overrides)
  - Update `agent-dispatch.sh` to source defaults first, then overrides, then `defaults.sh`
  - Create separate example files: `config.defaults.env.example` and updated `config.env.example`
  - Update setup skill, workflow templates, and CLAUDE.md documentation
  - Fixes standalone mode where `*.env` gitignore patterns (e.g., VisualStudio.gitignore) excluded config.env from
  checkout, causing workflow failures

  ## Config loading order

  1. `config.defaults.env` — committed, auto-discovered relative to scripts dir
  2. `config.env` — gitignored, optional (via `AGENT_CONFIG` env var or auto-discovered)
  3. `defaults.sh` — fills in anything still unset
  4. Environment variables — highest precedence throughout

  ## Test plan
  - [x] All 110 BATS tests pass
  - [x] ShellCheck passes on all scripts
  - [x] Bot tests still pass (71/71)
  - [ ] Deploy to demo repos and verify triage workflow succeeds

  🤖 Generated with [Claude Code](https://claude.com/claude-code)