### PR TITLE
Add conditional data-request behavior to default prompts

### DIFF
--- a/prompts/implement.md
+++ b/prompts/implement.md
@@ -34,6 +34,10 @@ If data files were attached ($AGENT_DATA_COMMENT_FILE or $AGENT_GIST_FILES are n
 - Read and analyze logs for error patterns, state transitions, and anomalies.
 - Use this data to inform your understanding of the root cause.
 
+If the issue describes a bug that depends on runtime state (timing, data-dependent behavior, environment-specific failures) and the attached data is insufficient or missing:
+- Note the gap in your implementation summary — describe what specific data would help and why.
+- Proceed with what you can determine from the code. Do not block on missing data if you can still make progress.
+
 ### Step 3: Follow TDD -- Red/Green/Refactor
 For each change in the plan:
 1. **RED**: Write a minimal failing test for the desired behavior

--- a/prompts/triage.md
+++ b/prompts/triage.md
@@ -11,17 +11,22 @@ Read the issue details from environment variables:
 3. Analyze the issue carefully against what you find in the code.
 4. Decide if you have enough information to create an implementation plan, or if you need to ask clarifying questions.
 
-## When to Ask Questions
-Ask clarifying questions if ANY of these are true:
-- The issue is vague or ambiguous about what behavior is expected
-- Multiple valid interpretations exist and the wrong choice would waste effort
-- The issue references something you cannot find in the codebase
-- The scope is unclear (could be a small fix or a large refactor)
-- You need reproduction steps or test cases to understand the bug
-- Key implementation details are missing (e.g., format, behavior, visual style, placement) and different choices would lead to meaningfully different implementations
-- The issue describes a goal but not the specifics of how to achieve it
+## Decision: Proceed or Ask
 
-Do NOT make assumptions about missing details to avoid asking questions. If the issue leaves important decisions unspecified, ask. A wrong assumption wastes more time than a clarifying question.
+After investigating the codebase, decide whether you can write a concrete implementation plan.
+
+### Default: Proceed
+Most issues contain enough information to act on. If the issue describes a bug with observable symptoms, a feature with a clear outcome, or a change with an obvious scope — investigate the code and write a plan. Do not ask questions you can answer by reading the codebase. When implementation details are unspecified but the codebase has clear patterns to follow, make a reasonable choice and note it in your plan.
+
+### Ask only when you cannot make progress
+Request clarification when ALL of these are true:
+1. You have already investigated the relevant code
+2. The missing information cannot be found in the codebase, issue, or comments
+3. Proceeding without the answer would likely produce a wrong implementation (not just a suboptimal one)
+
+When asking, each question must reference what you already investigated and explain why you cannot proceed without the answer. Ask no more than 3 focused questions.
+
+Each question delays the fix by a full human-response cycle. Only ask when the cost of guessing wrong exceeds the cost of waiting.
 
 ## If You Need Clarification
 Output ONLY a JSON object (no markdown, no code fences):


### PR DESCRIPTION
Restructure triage.md "When to Ask Questions" to use a "Default: Proceed" pattern — investigation-gated, cost-aware, with a specificity requirement for questions. This prevents agents from over-asking while still allowing data requests when genuinely needed.

Add data sufficiency assessment to implement.md — agents note when attached data is insufficient for runtime-dependent bugs without blocking progress.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

## Testing

<!-- How was this tested? -->
- [ ] ShellCheck passes (`shellcheck scripts/*.sh scripts/lib/*.sh`)
- [ ] BATS tests pass (`./tests/bats/bin/bats tests/`)
- [ ] Manual verification (describe what you tested)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
