### PR TITLE
docs: recommend standalone mode over reference mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Both options will:
 
 | Mode | How it works | Best for |
 |------|-------------|----------|
-| **Reference** | Thin workflow files in your repo call reusable workflows from this repo via `@v1` tags | Users who want automatic updates |
-| **Standalone** | All scripts, prompts, and workflows copied into your repo under `.agent-dispatch/` | Users who want full control and no upstream dependency |
+| **Standalone** (recommended) | All scripts, prompts, and workflows copied into your repo under `.agent-dispatch/` | Most users — full control, per-repo isolation |
+| **Reference** | Thin workflow files in your repo call reusable workflows from this repo via `@v1` tags | Advanced users who want automatic updates |
 
 ### Test It
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -146,7 +146,21 @@ Replace `my-project-bot` and `ghp_YOUR_BOT_PAT` with your actual bot username an
 
 claude-agent-dispatch supports two modes. Choose based on your needs:
 
-### Reference mode (recommended)
+### Standalone mode (recommended)
+
+All scripts, prompts, and workflow files are copied directly into your target repo under `.agent-dispatch/`. No external dependency.
+
+**Pros:**
+- Full control over every file -- customize freely
+- No external dependency at runtime
+- Everything is versioned alongside your project
+- Per-repo configuration isolation out of the box
+
+**Cons:**
+- More files in your repo
+- No automatic updates -- use the `/update` skill to sync improvements
+
+### Reference mode
 
 Thin caller workflow files live in your target repo and call back to the upstream `claude-agent-dispatch` reusable workflows. Scripts run from a clone of this repo on the runner.
 
@@ -159,20 +173,7 @@ Thin caller workflow files live in your target repo and call back to the upstrea
 - Requires cloning this repo on every runner
 - Depends on an external repository being available
 - Updates could introduce breaking changes (pin to a version tag to mitigate)
-
-### Standalone mode
-
-All scripts, prompts, and workflow files are copied directly into your target repo under `.agent-dispatch/`. No external dependency.
-
-**Pros:**
-- Full control over every file -- customize freely
-- No external dependency at runtime
-- Everything is versioned alongside your project
-
-**Cons:**
-- More files in your repo
-- No automatic updates -- you must manually sync improvements
-- Prompt and script drift if the upstream evolves
+- Shared config across repos on the same runner -- per-repo overrides require extra setup
 
 ---
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -213,7 +213,7 @@ git -C ~/repos/default/my-repo worktree prune
 
 ## Updating the Dispatch Scripts
 
-### Reference Mode (recommended)
+### Reference Mode
 
 If your project calls the reusable workflows from this repository, you are already in reference mode. The dispatch scripts live in the `claude-agent-dispatch` repository and your project references them via `workflow_call`.
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -32,15 +32,15 @@ echo -e "${BOLD}Step 1: Setup Mode${NC}"
 echo ""
 echo "How would you like to set up the agent dispatch system?"
 echo ""
-echo "  [1] Reference mode (recommended)"
+echo "  [1] Standalone mode (recommended)"
+echo "      All scripts, prompts, and workflows are copied into your repo."
+echo "      You own everything and can modify freely."
+echo "      Per-repo config isolation out of the box."
+echo ""
+echo "  [2] Reference mode"
 echo "      Workflows in your repo call back to this upstream repo."
 echo "      Scripts run from a clone on your runner."
 echo "      You get updates automatically via version tags."
-echo ""
-echo "  [2] Standalone mode"
-echo "      All scripts, prompts, and workflows are copied into your repo."
-echo "      You own everything and can modify freely."
-echo "      No upstream dependency — but no automatic updates either."
 echo ""
 
 read -rp "Choose mode [1/2]: " SETUP_MODE
@@ -49,6 +49,13 @@ SETUP_MODE="${SETUP_MODE:-1}"
 if [[ "$SETUP_MODE" != "1" && "$SETUP_MODE" != "2" ]]; then
     echo -e "${RED}Invalid choice. Please enter 1 or 2.${NC}"
     exit 1
+fi
+
+# Map user-facing numbering to internal: 1=standalone(internal 2), 2=reference(internal 1)
+if [[ "$SETUP_MODE" == "1" ]]; then
+    SETUP_MODE="2"
+elif [[ "$SETUP_MODE" == "2" ]]; then
+    SETUP_MODE="1"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

- Standalone mode is now marked as **(recommended)** across all docs and the setup script
- Reference mode repositioned as an advanced option for users who want automatic updates
- `setup.sh` menu reordered so standalone is option [1] (the default)
- Standalone pros/cons updated to mention per-repo config isolation and `/update` skill

**Files changed:**
- `README.md` — mode comparison table
- `docs/getting-started.md` — setup mode section (reordered, updated pros/cons)
- `docs/operations.md` — removed "(recommended)" from Reference Mode heading
- `scripts/setup.sh` — swapped menu order with internal remapping

The setup SKILL.md was already updated in a prior commit.

## Test plan

- [x] Verify `setup.sh` still works: option 1 → standalone, option 2 → reference, default (enter) → standalone
- [x] Confirm no other docs reference "reference mode (recommended)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)