### PR TITLE
feat: detect new workflow templates during /update (#17)

### DIFF
--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -106,7 +106,9 @@ For each new upstream file, show its contents and ask if the user wants to add i
 
 ## Step 6: Detect New Workflow Templates
 
-After applying updates to `.agent-dispatch/`, check whether upstream has added any new workflow templates that the user's repo doesn't have yet.
+Step 5 handles new files within `.agent-dispatch/`. This step handles workflow templates that need to be installed to `.github/workflows/` with bot username substitution — a separate concern.
+
+Check whether upstream has added any new workflow templates that the user's repo doesn't have yet.
 
 ### Scan for new templates
 
@@ -128,19 +130,15 @@ For each new template:
      agent-direct-implement.yml — "Claude Agent: Direct Implement" (triggers on issues labeled)
    ```
 
-2. **Confirm bot username:** Read `AGENT_BOT_USER` from `.agent-dispatch/config.defaults.env`. Ask the user to confirm: "I'll substitute `<bot-username>` for the bot user in the workflow — does that look right?"
+2. **Confirm bot username (first template only):** Read `AGENT_BOT_USER` from `.agent-dispatch/config.defaults.env`. If it is empty or not set, also check `.agent-dispatch/config.env` (if it exists). If still not found, ask the user to provide the bot username. Ask the user to confirm: "I'll substitute `<bot-username>` for the bot user in the workflow — does that look right?" Reuse the confirmed value for all subsequent templates without re-asking.
 
 3. **Show the generated workflow:** Read the template, replace all `{{BOT_USER}}` occurrences with the confirmed bot username, and show the result to the user.
 
-4. **Ask to install:** "Install this workflow to `.github/workflows/agent-direct-implement.yml`?"
+4. **Ask to install:** "Install this workflow to `.github/workflows/<template-filename>`?"
    - If yes: write the file (create `.github/workflows/` if it doesn't exist).
    - If no: skip it.
 
 5. Repeat for each new template.
-
-### Bot username confirmation
-
-Only ask for bot username confirmation once (on the first new template). Reuse the confirmed value for all subsequent templates in the same update run.
 
 ## Step 7: Update Tracking
 

--- a/.claude/skills/update/SKILL.md
+++ b/.claude/skills/update/SKILL.md
@@ -104,7 +104,45 @@ For each file that both sides modified:
 ### New files
 For each new upstream file, show its contents and ask if the user wants to add it.
 
-## Step 6: Update Tracking
+## Step 6: Detect New Workflow Templates
+
+After applying updates to `.agent-dispatch/`, check whether upstream has added any new workflow templates that the user's repo doesn't have yet.
+
+### Scan for new templates
+
+1. List all `.yml` files in the upstream clone's `.claude/skills/setup/templates/standalone/` directory.
+2. For each template file (e.g., `agent-direct-implement.yml`), check if `.github/workflows/<same-filename>` exists in the user's repo.
+3. Collect any templates that don't have a matching installed workflow — these are new.
+
+### If no new templates found
+
+Report: "No new workflow templates detected." and proceed to the next step.
+
+### If new templates found
+
+For each new template:
+
+1. **Describe it:** Read the template's `name:` field and `on:` trigger to give the user a one-line summary. Example:
+   ```
+   New workflow template available:
+     agent-direct-implement.yml — "Claude Agent: Direct Implement" (triggers on issues labeled)
+   ```
+
+2. **Confirm bot username:** Read `AGENT_BOT_USER` from `.agent-dispatch/config.defaults.env`. Ask the user to confirm: "I'll substitute `<bot-username>` for the bot user in the workflow — does that look right?"
+
+3. **Show the generated workflow:** Read the template, replace all `{{BOT_USER}}` occurrences with the confirmed bot username, and show the result to the user.
+
+4. **Ask to install:** "Install this workflow to `.github/workflows/agent-direct-implement.yml`?"
+   - If yes: write the file (create `.github/workflows/` if it doesn't exist).
+   - If no: skip it.
+
+5. Repeat for each new template.
+
+### Bot username confirmation
+
+Only ask for bot username confirmation once (on the first new template). Reuse the confirmed value for all subsequent templates in the same update run.
+
+## Step 7: Update Tracking
 
 After applying changes, update `.agent-dispatch/.upstream`:
 - Set `version` to the latest upstream commit SHA
@@ -112,12 +150,13 @@ After applying changes, update `.agent-dispatch/.upstream`:
 
 Write the updated `.upstream` file.
 
-## Step 7: Summary
+## Step 8: Summary
 
 Tell the user:
 - How many files were updated, skipped, and merged
+- How many new workflow templates were installed (if any)
 - If any manual review items remain
-- Remind them to commit the changes: `git add .agent-dispatch/ && git commit -m "Update agent-dispatch from upstream"`
+- Remind them to commit the changes: `git add .agent-dispatch/ .github/workflows/ && git commit -m "Update agent-dispatch from upstream"`
 
 ## File Format: .agent-dispatch/.upstream
 

--- a/docs/issues/update-skill-workflow-templates.md
+++ b/docs/issues/update-skill-workflow-templates.md
@@ -1,5 +1,7 @@
 # Update Skill: Handle New Workflow Templates
 
+> **Status:** Implemented — new Step 6 in `/update` skill detects and offers to install new workflow templates.
+
 ## Summary
 
 The `/update` skill should detect new standalone workflow templates from upstream and offer to install them, rather than requiring manual creation after each update.

--- a/docs/superpowers/plans/2026-04-07-update-skill-workflow-detection.md
+++ b/docs/superpowers/plans/2026-04-07-update-skill-workflow-detection.md
@@ -1,0 +1,152 @@
+# Update Skill: Workflow Template Detection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a step to the `/update` skill that detects new upstream workflow templates and offers to install them into the user's `.github/workflows/`.
+
+**Architecture:** The update skill is a Claude Code skill defined entirely in `.claude/skills/update/SKILL.md`. The change is a new step inserted between the current Step 5 (Apply Updates) and Step 6 (Update Tracking). No shell scripts, no `.upstream` format changes.
+
+**Tech Stack:** Markdown (SKILL.md instructions), YAML (workflow templates)
+
+---
+
+### Task 1: Add workflow template detection step to update SKILL.md
+
+**Files:**
+- Modify: `.claude/skills/update/SKILL.md:106` (insert new step after current Step 5, renumber Steps 6-7 to 7-8)
+
+- [ ] **Step 1: Read the current SKILL.md to confirm structure**
+
+Run:
+```bash
+grep -n "^## Step" .claude/skills/update/SKILL.md
+```
+
+Expected output (confirm step numbering before editing):
+```
+18:## Step 1: Locate the Installation
+29:## Step 2: Fetch Latest Upstream
+45:## Step 3: Categorize Files
+63:## Step 4: Present Summary
+89:## Step 5: Apply Updates
+107:## Step 6: Update Tracking
+115:## Step 7: Summary
+```
+
+- [ ] **Step 2: Insert the new Step 6 after the current Step 5 (Apply Updates)**
+
+After line 106 (end of current Step 5), insert the following new section:
+
+```markdown
+## Step 6: Detect New Workflow Templates
+
+After applying updates to `.agent-dispatch/`, check whether upstream has added any new workflow templates that the user's repo doesn't have yet.
+
+### Scan for new templates
+
+1. List all `.yml` files in the upstream clone's `.claude/skills/setup/templates/standalone/` directory.
+2. For each template file (e.g., `agent-direct-implement.yml`), check if `.github/workflows/<same-filename>` exists in the user's repo.
+3. Collect any templates that don't have a matching installed workflow — these are new.
+
+### If no new templates found
+
+Report: "No new workflow templates detected." and proceed to the next step.
+
+### If new templates found
+
+For each new template:
+
+1. **Describe it:** Read the template's `name:` field and `on:` trigger to give the user a one-line summary. Example:
+   ```
+   New workflow template available:
+     agent-direct-implement.yml — "Claude Agent: Direct Implement" (triggers on issues labeled)
+   ```
+
+2. **Confirm bot username:** Read `AGENT_BOT_USER` from `.agent-dispatch/config.defaults.env`. Ask the user to confirm: "I'll substitute `<bot-username>` for the bot user in the workflow — does that look right?"
+
+3. **Show the generated workflow:** Read the template, replace all `{{BOT_USER}}` occurrences with the confirmed bot username, and show the result to the user.
+
+4. **Ask to install:** "Install this workflow to `.github/workflows/agent-direct-implement.yml`?"
+   - If yes: write the file (create `.github/workflows/` if it doesn't exist).
+   - If no: skip it.
+
+5. Repeat for each new template.
+
+### Bot username confirmation
+
+Only ask for bot username confirmation once (on the first new template). Reuse the confirmed value for all subsequent templates in the same update run.
+```
+
+- [ ] **Step 3: Renumber the existing Steps 6 and 7**
+
+Change the current "Step 6: Update Tracking" heading to "Step 7: Update Tracking".
+
+Change the current "Step 7: Summary" heading to "Step 8: Summary".
+
+- [ ] **Step 4: Update the Summary step to mention workflow templates**
+
+In the newly renumbered Step 8 (Summary), add a line after "How many files were updated, skipped, and merged":
+
+```markdown
+- How many new workflow templates were installed (if any)
+```
+
+Also update the suggested commit command to include workflow files:
+
+```markdown
+- Remind them to commit the changes: `git add .agent-dispatch/ .github/workflows/ && git commit -m "Update agent-dispatch from upstream"`
+```
+
+- [ ] **Step 5: Verify the complete SKILL.md reads correctly**
+
+Read the full updated SKILL.md and verify:
+- Steps are numbered 1-8 sequentially with no gaps
+- Step 6 (new) flows logically between Step 5 (Apply Updates) and Step 7 (Update Tracking)
+- No references to old step numbers remain in the document
+- The `.upstream` file format section at the bottom is unchanged
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .claude/skills/update/SKILL.md
+git commit -m "feat: detect new workflow templates during /update (#17)"
+```
+
+---
+
+### Task 2: Update the issue documentation
+
+**Files:**
+- Modify: `docs/issues/update-skill-workflow-templates.md` (add implementation status)
+
+- [ ] **Step 1: Add a resolution note to the issue doc**
+
+At the top of `docs/issues/update-skill-workflow-templates.md`, add:
+
+```markdown
+> **Status:** Implemented — new Step 6 in `/update` skill detects and offers to install new workflow templates.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/issues/update-skill-workflow-templates.md
+git commit -m "docs: mark workflow template detection as implemented (#17)"
+```
+
+---
+
+### Task 3: Manual testing
+
+- [ ] **Step 1: Verify detection logic by inspection**
+
+On a standalone installation (e.g., Frightful-Games/Webber), confirm:
+1. The upstream `templates/standalone/` directory contains 7 templates: `agent-triage.yml`, `agent-implement.yml`, `agent-reply.yml`, `agent-review.yml`, `agent-cleanup.yml`, `agent-dispatch.yml`, `agent-direct-implement.yml`
+2. The target repo's `.github/workflows/` contains the installed workflows
+3. Any missing workflow would be detected by the filename comparison logic described in Step 6
+
+- [ ] **Step 2: Close the GitHub issue**
+
+```bash
+gh issue close 17 --comment "Implemented in [commit SHA]. The /update skill now detects new workflow templates and offers to install them."
+```

--- a/docs/superpowers/specs/2026-04-07-update-skill-workflow-detection-design.md
+++ b/docs/superpowers/specs/2026-04-07-update-skill-workflow-detection-design.md
@@ -1,0 +1,69 @@
+# Design: Workflow Template Detection in `/update` Skill
+
+**Date:** 2026-04-07
+**Issue:** #17 — Update skill: detect new workflow templates and offer to install them
+**Scope:** Standalone mode only
+
+## Problem
+
+When upstream adds a new workflow template (e.g., `agent-direct-implement.yml` for the `agent:implement` feature), the `/update` skill syncs scripts, prompts, and labels correctly but does not detect the new template. Users must manually discover and create the corresponding workflow file in `.github/workflows/`.
+
+This was encountered during the `agent:implement` rollout to Frightful-Games/Webber (2026-04-05), where `/update` synced 11 files but missed the new workflow template entirely.
+
+## Approach
+
+Add a new step to the update SKILL.md between "Apply Updates" (current Step 5) and "Update Tracking" (current Step 6). This step instructs Claude to scan upstream templates and offer to install any that are missing from the user's repo.
+
+No changes to `setup.sh`, the `.upstream` file format, or any shell scripts. The update skill is already an interactive Claude-guided flow; this adds one more step to those instructions.
+
+## Design
+
+### Detection Logic
+
+1. Glob the upstream clone's `.claude/skills/setup/templates/standalone/` for all `.yml` files.
+2. For each template, derive the expected installed filename by stripping the `standalone/` prefix (e.g., `standalone/agent-direct-implement.yml` → `agent-direct-implement.yml`).
+3. Check if `.github/workflows/<filename>` exists in the user's repo.
+4. Any template without a matching installed workflow is flagged as new.
+
+### Installation Flow (per new template)
+
+1. Show the template name and a brief description (from the workflow's `name:` field and trigger type).
+2. Read `AGENT_BOT_USER` from `.agent-dispatch/config.defaults.env` and confirm with the user (e.g., "I'll use `pennyworth-bot` from your config — does that look right?").
+3. Apply `{{BOT_USER}}` substitution to the template content.
+4. Show the generated workflow to the user.
+5. Ask if they want to install it to `.github/workflows/`.
+6. If yes, write the file. If no, skip.
+
+### No New Templates
+
+If all upstream templates already have matching workflows, report "No new workflow templates detected" and move on to the next step.
+
+### What This Does NOT Do
+
+- **Modify existing workflows.** Only new (missing) templates are offered. Installed workflows are never touched.
+- **Track workflows in `.upstream`.** The `.upstream` file format is unchanged. Detection is based on filesystem comparison, not a manifest.
+- **Remove workflows.** If upstream deletes a template, the installed workflow is left in place. There is no reliable way to distinguish "upstream removed this" from "user created this themselves."
+- **Propagate env vars from existing workflows.** New templates ship with the standard env block (`GH_TOKEN`, `GITHUB_TOKEN`, `AGENT_CONFIG`). If the user has added custom secrets to other workflows, they handle that themselves after installation.
+- **Touch `.env` files.** Config files are owned by the environment and are never modified by the update skill.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| User renamed a workflow file | Detected as "new" since expected filename is missing. User declines installation. Harmless. |
+| `.github/workflows/` directory doesn't exist | Create it before writing (unlikely in standalone, but defensive). |
+| `agent-dispatch.yml` (Discord bot dispatch) template | Treated the same as any other template. User declines if they don't use the Discord bot. |
+| `AGENT_BOT_USER` not found in config | Ask the user to provide the bot username manually. |
+| No upstream templates directory | Skip the step entirely (shouldn't happen, but graceful no-op). |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.claude/skills/update/SKILL.md` | Add new step for workflow template detection between current Steps 5 and 6. |
+
+## Testing
+
+- Run `/update` on a standalone installation that is missing a workflow template and verify it is detected and offered for installation.
+- Run `/update` on a standalone installation with all workflows present and verify "No new workflow templates" is reported.
+- Verify `{{BOT_USER}}` substitution produces correct output matching existing installed workflows.


### PR DESCRIPTION
## Summary

- Adds new Step 6 "Detect New Workflow Templates" to the `/update` skill (`SKILL.md`)
- After applying file updates, the skill now scans upstream `templates/standalone/` and compares against installed `.github/workflows/` files
- New templates are offered for installation with `{{BOT_USER}}` substitution and user confirmation
- Existing steps renumbered (6→7, 7→8), summary step updated to include template counts

**Design spec:** `docs/superpowers/specs/2026-04-07-update-skill-workflow-detection-design.md`

Closes #17

## Test plan

- [ ] Run `/update` on a standalone installation missing a workflow template — verify it's detected and offered
- [ ] Run `/update` on a standalone installation with all workflows present — verify "No new workflow templates" reported
- [ ] Verify `{{BOT_USER}}` substitution matches existing installed workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)