### PR TITLE
feat: add /test skill with platform-aware prerequisite detection

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -47,19 +47,9 @@ Run the full test suite:
 
 ## Step 4: Interpret Results
 
-Categorize every failure as either a **known platform limitation** or a **real failure**.
+If Step 1 passed (all prerequisites met), all tests should pass. Any failure is a real regression — investigate it.
 
-### Known platform limitations (not real failures)
-
-| Platform | Issue | Affected Tests | Why |
-|----------|-------|---------------|-----|
-| Windows (git-bash) | `grep -P` unavailable | ~5 tests in `test_data_fetch.bats` | Git Bash ships BusyBox grep without PCRE. Tests pass in CI (Linux). |
-
-If a test fails and uses `grep -P` on Windows, count it as a known limitation, not a failure.
-
-### Everything else is a real failure
-
-Any test failure that is NOT in the known-limitations table above is a real regression. Investigate it.
+If tests fail with errors about `jq`, `shellcheck`, `grep -P`, or `bats`, re-run Step 1 — a prerequisite is missing.
 
 ## Step 5: Report Summary
 

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: test
+description: Use when running tests, verifying code changes, or before commits/PRs in this repository. Checks prerequisites, runs ShellCheck and BATS, categorizes results.
+user-invocable: true
+---
+
+# Test: Run ShellCheck and BATS with Prerequisite Detection
+
+Run the project test suite with prerequisite checking and platform-aware result interpretation.
+
+## Step 1: Check Prerequisites
+
+Run the prerequisite detection script:
+
+```bash
+bash ${CLAUDE_SKILL_DIR}/../../../scripts/check-test-prereqs.sh
+```
+
+If any tools are missing:
+- Show the user what's missing and the install commands from the script output
+- Ask if they want you to run the install commands or if they'll do it manually
+- Do NOT proceed to Steps 2-3 until prerequisites pass
+
+## Step 2: Run ShellCheck
+
+Run ShellCheck on all shell scripts:
+
+```bash
+shellcheck scripts/*.sh scripts/lib/*.sh
+```
+
+**Windows CRLF fallback:** If you see SC1017 errors ("Expected a function name but found end of line"), the files have CRLF line endings. Fix by running:
+
+```bash
+git add --renormalize . && git checkout -- .
+```
+
+Then re-run shellcheck.
+
+## Step 3: Run BATS Tests
+
+Run the full test suite:
+
+```bash
+./tests/bats/bin/bats tests/
+```
+
+## Step 4: Interpret Results
+
+Categorize every failure as either a **known platform limitation** or a **real failure**.
+
+### Known platform limitations (not real failures)
+
+| Platform | Issue | Affected Tests | Why |
+|----------|-------|---------------|-----|
+| Windows (git-bash) | `grep -P` unavailable | ~5 tests in `test_data_fetch.bats` | Git Bash ships BusyBox grep without PCRE. Tests pass in CI (Linux). |
+
+If a test fails and uses `grep -P` on Windows, count it as a known limitation, not a failure.
+
+### Everything else is a real failure
+
+Any test failure that is NOT in the known-limitations table above is a real regression. Investigate it.
+
+## Step 5: Report Summary
+
+Report results in this format:
+
+```
+ShellCheck: PASS (N files checked)
+BATS: X/Y tests passed. Z skipped. N known platform limitations. M real failures.
+```
+
+If there are real failures, list each one with the test name and error output.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Default: let Git detect text files and normalize line endings
+* text=auto
+
+# Force LF line endings for shell scripts and related files
+# Prevents CRLF issues on Windows with core.autocrlf=true
+*.sh text eol=lf
+*.bash text eol=lf
+*.bats text eol=lf
+Makefile text eol=lf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,6 @@ Run `/setup` to configure this toolkit for your project.
 
 ### Local Test Prerequisites
 
-Required tools: `jq`, `shellcheck`, BATS-Core (git submodule)
+Required tools: `jq`, `shellcheck`, `grep -P` (PCRE support), BATS-Core (git submodule)
 
-Run `bash scripts/check-test-prereqs.sh` to detect missing tools with platform-specific install instructions.
-
-Known limitation: ~5 `grep -P` tests in `test_data_fetch.bats` fail on Windows (git-bash) due to missing PCRE support. These pass in CI (Linux).
+Run `bash scripts/check-test-prereqs.sh` to detect missing tools with platform-specific install instructions. All tests should pass when prerequisites are met.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,16 @@ Run `/setup` to configure this toolkit for your project.
 - All shell scripts must pass `shellcheck` with zero warnings
 - Tests use BATS-Core (git submodules in `tests/`)
 - Run checks: `shellcheck scripts/*.sh scripts/lib/*.sh && ./tests/bats/bin/bats tests/`
+- Use `/test` skill for local testing (handles prerequisites and platform differences)
 - CI runs both ShellCheck and BATS on every push and PR
 - Use `set -euo pipefail` in all scripts
 - Keep functions focused — one purpose per function
 - Bug fix? Add a `REGRESSION vX.Y.Z:` test to prevent recurrence
+
+### Local Test Prerequisites
+
+Required tools: `jq`, `shellcheck`, BATS-Core (git submodule)
+
+Run `bash scripts/check-test-prereqs.sh` to detect missing tools with platform-specific install instructions.
+
+Known limitation: ~5 `grep -P` tests in `test_data_fetch.bats` fail on Windows (git-bash) due to missing PCRE support. These pass in CI (Linux).

--- a/scripts/check-test-prereqs.sh
+++ b/scripts/check-test-prereqs.sh
@@ -49,6 +49,15 @@ echo ""
 check_tool "jq"
 check_tool "shellcheck"
 
+# ─── grep -P (PCRE) support check ─────────────────────────────
+
+if echo "test" | grep -P "test" &>/dev/null; then
+    echo -e "  ${GREEN}✓${NC} grep -P (PCRE) supported"
+else
+    echo -e "  ${RED}✗${NC} grep -P (PCRE) not supported"
+    MISSING+=("grep-pcre")
+fi
+
 # ─── Bats submodule check ─────────────────────────────────────
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -88,6 +97,14 @@ if [ ${#MISSING[@]} -ne 0 ]; then
                     macos)   echo "  shellcheck: brew install shellcheck" ;;
                     windows) echo "  shellcheck: winget install koalaman.shellcheck" ;;
                     *)       echo "  shellcheck: see https://github.com/koalaman/shellcheck#installing" ;;
+                esac
+                ;;
+            grep-pcre)
+                case "$PLATFORM" in
+                    linux)   echo "  grep -P:    sudo apt-get install -y grep  (usually pre-installed)" ;;
+                    macos)   echo "  grep -P:    brew install grep  (use ggrep or add to PATH)" ;;
+                    windows) echo "  grep -P:    pacman -S grep  (run in Git Bash as admin, requires MSYS2)" ;;
+                    *)       echo "  grep -P:    install GNU grep with PCRE support" ;;
                 esac
                 ;;
             bats)

--- a/scripts/check-test-prereqs.sh
+++ b/scripts/check-test-prereqs.sh
@@ -8,7 +8,6 @@ set -euo pipefail
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
 NC='\033[0m'
 
 MISSING=()
@@ -56,8 +55,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BATS_BIN="${SCRIPT_DIR}/../tests/bats/bin/bats"
 
 if [ -x "$BATS_BIN" ]; then
-    local_version=$("$BATS_BIN" --version 2>&1 | head -1)
-    echo -e "  ${GREEN}✓${NC} bats found: ${local_version}"
+    bats_version=$("$BATS_BIN" --version 2>&1 | head -1)
+    echo -e "  ${GREEN}✓${NC} bats found: ${bats_version}"
 else
     echo -e "  ${RED}✗${NC} bats submodule not initialized — not found"
     MISSING+=("bats")

--- a/scripts/check-test-prereqs.sh
+++ b/scripts/check-test-prereqs.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+set -euo pipefail
+
+# ─── Check prerequisites for running tests locally ─────────────
+# Usage: bash scripts/check-test-prereqs.sh
+# Exits 0 if all tools present, 1 if any missing.
+# Reports platform and install instructions for missing tools.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+MISSING=()
+
+# ─── Platform detection ────────────────────────────────────────
+
+detect_platform() {
+    local uname_out
+    uname_out="$(uname -s)"
+    case "$uname_out" in
+        Linux*)                echo "linux" ;;
+        Darwin*)               echo "macos" ;;
+        MINGW*|MSYS*|CYGWIN*) echo "windows" ;;
+        *)                     echo "unknown" ;;
+    esac
+}
+
+PLATFORM="$(detect_platform)"
+echo -e "Platform: ${PLATFORM}"
+echo ""
+
+# ─── Tool checks ──────────────────────────────────────────────
+
+check_tool() {
+    local tool="$1"
+    if command -v "$tool" &>/dev/null; then
+        local version
+        version=$("$tool" --version 2>&1 | head -1)
+        echo -e "  ${GREEN}✓${NC} ${tool} found: ${version}"
+    else
+        echo -e "  ${RED}✗${NC} ${tool} not found"
+        MISSING+=("$tool")
+    fi
+}
+
+echo "Checking test prerequisites..."
+echo ""
+
+check_tool "jq"
+check_tool "shellcheck"
+
+# ─── Bats submodule check ─────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BATS_BIN="${SCRIPT_DIR}/../tests/bats/bin/bats"
+
+if [ -x "$BATS_BIN" ]; then
+    local_version=$("$BATS_BIN" --version 2>&1 | head -1)
+    echo -e "  ${GREEN}✓${NC} bats found: ${local_version}"
+else
+    echo -e "  ${RED}✗${NC} bats submodule not initialized — not found"
+    MISSING+=("bats")
+fi
+
+echo ""
+
+# ─── Install instructions ─────────────────────────────────────
+
+if [ ${#MISSING[@]} -ne 0 ]; then
+    echo -e "${RED}Missing: ${MISSING[*]}${NC}"
+    echo ""
+    echo "Install instructions for ${PLATFORM}:"
+    echo ""
+
+    for tool in "${MISSING[@]}"; do
+        case "$tool" in
+            jq)
+                case "$PLATFORM" in
+                    linux)   echo "  jq:         sudo apt-get install -y jq" ;;
+                    macos)   echo "  jq:         brew install jq" ;;
+                    windows) echo "  jq:         winget install jqlang.jq" ;;
+                    *)       echo "  jq:         see https://jqlang.github.io/jq/download/" ;;
+                esac
+                ;;
+            shellcheck)
+                case "$PLATFORM" in
+                    linux)   echo "  shellcheck: sudo apt-get install -y shellcheck" ;;
+                    macos)   echo "  shellcheck: brew install shellcheck" ;;
+                    windows) echo "  shellcheck: winget install koalaman.shellcheck" ;;
+                    *)       echo "  shellcheck: see https://github.com/koalaman/shellcheck#installing" ;;
+                esac
+                ;;
+            bats)
+                echo "  bats:       git submodule update --init --recursive"
+                ;;
+        esac
+    done
+
+    echo ""
+    exit 1
+fi
+
+echo -e "${GREEN}All test prerequisites met.${NC}"

--- a/tests/test_check_prereqs.bats
+++ b/tests/test_check_prereqs.bats
@@ -65,6 +65,16 @@ load 'helpers/test_helper'
 }
 
 # ═══════════════════════════════════════════════════════════════
+# grep -P (PCRE) detection
+# ═══════════════════════════════════════════════════════════════
+
+@test "check-test-prereqs: checks for grep -P support" {
+    run bash "${SCRIPTS_DIR}/check-test-prereqs.sh"
+    # Output should mention PCRE regardless of whether it's supported or not
+    assert_output --partial "grep -P"
+}
+
+# ═══════════════════════════════════════════════════════════════
 # Bats submodule detection
 # ═══════════════════════════════════════════════════════════════
 

--- a/tests/test_check_prereqs.bats
+++ b/tests/test_check_prereqs.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# Tests for scripts/check-test-prereqs.sh
+
+load 'helpers/test_helper'
+
+# ═══════════════════════════════════════════════════════════════
+# Platform detection
+# ═══════════════════════════════════════════════════════════════
+
+@test "check-test-prereqs: detects platform" {
+    run bash "${SCRIPTS_DIR}/check-test-prereqs.sh"
+    assert_output --partial "Platform:"
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Tool detection — all present
+# ═══════════════════════════════════════════════════════════════
+
+@test "check-test-prereqs: exits 0 when all tools are present" {
+    # Only run if tools are actually present on this system
+    if ! command -v jq &>/dev/null || ! command -v shellcheck &>/dev/null; then
+        skip "jq or shellcheck not installed on this system"
+    fi
+    if [ ! -x "${SCRIPTS_DIR}/../tests/bats/bin/bats" ]; then
+        skip "bats submodule not initialized"
+    fi
+
+    run bash "${SCRIPTS_DIR}/check-test-prereqs.sh"
+    assert_success
+    assert_output --partial "All test prerequisites met"
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Tool detection — missing tools
+# ═══════════════════════════════════════════════════════════════
+
+@test "check-test-prereqs: exits 1 when a required tool is missing" {
+    # Use a minimal PATH that won't have jq or shellcheck
+    # Keep only basic system dirs so bash itself works
+    run env PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash "${SCRIPTS_DIR}/check-test-prereqs.sh"
+    if [ "$status" -eq 0 ]; then
+        skip "all tools found even in restricted PATH"
+    fi
+    assert_failure
+}
+
+@test "check-test-prereqs: reports missing tool with install instructions" {
+    run env PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash "${SCRIPTS_DIR}/check-test-prereqs.sh"
+    if [ "$status" -eq 0 ]; then
+        skip "all tools found in restricted PATH"
+    fi
+    assert_failure
+    # Should contain install instructions
+    assert_output --partial "Install"
+}
+
+@test "check-test-prereqs: names the missing tool in output" {
+    run env PATH="/usr/bin:/bin:/usr/sbin:/sbin" bash "${SCRIPTS_DIR}/check-test-prereqs.sh"
+    if [ "$status" -eq 0 ]; then
+        skip "all tools found in restricted PATH"
+    fi
+    assert_failure
+    # Should name at least one missing tool
+    assert_output --partial "not found"
+}
+
+# ═══════════════════════════════════════════════════════════════
+# Bats submodule detection
+# ═══════════════════════════════════════════════════════════════
+
+@test "check-test-prereqs: detects missing bats submodule" {
+    # Copy script to a temp location so it looks for bats relative to itself
+    local fake_scripts="${TEST_TEMP_DIR}/scripts"
+    mkdir -p "$fake_scripts"
+    cp "${SCRIPTS_DIR}/check-test-prereqs.sh" "$fake_scripts/"
+
+    run bash "$fake_scripts/check-test-prereqs.sh"
+    assert_failure
+    assert_output --partial "bats"
+}


### PR DESCRIPTION
## Summary

Closes #29

- Adds `.gitattributes` to enforce LF line endings for shell scripts, preventing CRLF-related shellcheck and test failures on Windows
- Adds `scripts/check-test-prereqs.sh` — detects missing test prerequisites (`jq`, `shellcheck`, `grep -P` PCRE support, bats submodule) with platform-specific install instructions (apt-get/brew/winget/pacman)
- Adds project-local `/test` skill (`.claude/skills/test/SKILL.md`) that orchestrates: prerequisite check → shellcheck → BATS → result interpretation
- Updates `CLAUDE.md` with test prerequisites documentation and `/test` skill reference

## Test plan

- [ ] Run `bash scripts/check-test-prereqs.sh` on Linux — should detect all tools and exit 0
- [ ] Run `bash scripts/check-test-prereqs.sh` on Windows (Git Bash) with missing tools — should exit 1 with platform-specific install instructions
- [ ] Run `/test` skill in Claude Code — should check prereqs, run shellcheck, run BATS, and report summary
- [ ] Verify all BATS tests pass when prerequisites are installed (including `grep -P` tests)
- [ ] CI: ShellCheck passes on all scripts including new `check-test-prereqs.sh`
- [ ] CI: All BATS tests pass (Linux runner has all prerequisites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)