### PR TITLE
fix(review-gates): extract JSON from narrative preamble/fence/postamble

### DIFF
--- a/scripts/lib/review-gates.sh
+++ b/scripts/lib/review-gates.sh
@@ -3,6 +3,55 @@
 # Provides: run_adversarial_plan_review, run_post_impl_review,
 #           handle_post_impl_review_retry
 
+# ─── JSON extraction helper ─────────────────────────────────────
+# Claude sometimes prefixes a narrative preamble or wraps the JSON in
+# a markdown fence even when told not to. Extract the last balanced
+# {...} block so jq-based field lookups still work.
+#
+# Strategy: try parsing the whole text first (cheap path for compliant
+# responses); on failure, walk the text with awk, tracking brace depth,
+# and emit the last top-level object. Limitation: literal braces inside
+# quoted string values can fool the depth counter. The review gate
+# schemas (action/concerns/questions/corrections) use simple scalars and
+# string arrays, so this is acceptable in practice.
+_extract_review_json() {
+    local text="$1"
+    local whole_action
+    set +e
+    whole_action=$(printf '%s' "$text" | jq -r '.action // empty' 2>/dev/null)
+    set -e
+    if [ -n "$whole_action" ]; then
+        printf '%s' "$text"
+        return 0
+    fi
+
+    printf '%s' "$text" | awk '
+        BEGIN { depth = 0; in_obj = 0; buf = ""; last = "" }
+        {
+            line = $0
+            n = length(line)
+            for (i = 1; i <= n; i++) {
+                c = substr(line, i, 1)
+                if (c == "{") {
+                    if (depth == 0) { buf = ""; in_obj = 1 }
+                    depth++
+                }
+                if (in_obj) buf = buf c
+                if (c == "}") {
+                    if (depth > 0) depth--
+                    if (depth == 0 && in_obj) {
+                        last = buf
+                        in_obj = 0
+                        buf = ""
+                    }
+                }
+            }
+            if (in_obj) buf = buf "\n"
+        }
+        END { if (last != "") print last }
+    '
+}
+
 # ─── Gate A: Adversarial Plan Review ────────────────────────────
 # Runs a fresh Claude session to check the plan against the issue.
 # Returns 0 to proceed, 1 to halt implementation.
@@ -25,12 +74,13 @@ run_adversarial_plan_review() {
     claude_output=$(parse_claude_output "$result")
     log "Adversarial review result: ${claude_output:0:500}"
 
-    # Parse the action from the response
-    # claude_output is the result string from parse_claude_output, which may be
-    # a JSON object directly, or a JSON string that needs to be decoded.
-    local action
+    # claude_output may be a bare JSON object, a JSON object with narrative
+    # preamble/postamble, or wrapped in a markdown fence. _extract_review_json
+    # returns the last balanced {...} block so jq lookups succeed in all cases.
+    local json_block action
+    json_block=$(_extract_review_json "$claude_output")
     set +e
-    action=$(echo "$claude_output" | jq -r '.action // empty' 2>/dev/null || echo "")
+    action=$(printf '%s' "$json_block" | jq -r '.action // empty' 2>/dev/null || echo "")
     set -e
 
     case "$action" in
@@ -41,8 +91,8 @@ run_adversarial_plan_review() {
         corrected)
             log "Adversarial plan review: corrections made"
             local corrections revised_plan
-            corrections=$(echo "$claude_output" | jq -r '.corrections[]' 2>/dev/null | sed 's/^/- /')
-            revised_plan=$(echo "$claude_output" | jq -r '.revised_plan // empty' 2>/dev/null)
+            corrections=$(printf '%s' "$json_block" | jq -r '.corrections[]' 2>/dev/null | sed 's/^/- /')
+            revised_plan=$(printf '%s' "$json_block" | jq -r '.revised_plan // empty' 2>/dev/null)
 
             if [ -n "$revised_plan" ]; then
                 export AGENT_PLAN_CONTENT="$revised_plan"
@@ -62,7 +112,7 @@ Implementation will proceed with the corrected plan." 2>/dev/null || true
         needs_clarification)
             log "Adversarial plan review: needs clarification"
             local questions
-            questions=$(echo "$claude_output" | jq -r '.questions[]' 2>/dev/null | sed 's/^/- /')
+            questions=$(printf '%s' "$json_block" | jq -r '.questions[]' 2>/dev/null | sed 's/^/- /')
 
             gh issue comment "$NUMBER" --repo "$REPO" --body "<!-- agent-adversarial-review -->
 ## Adversarial Plan Review: Clarification Needed
@@ -110,9 +160,10 @@ run_post_impl_review() {
     claude_output=$(parse_claude_output "$result")
     log "Post-impl review result: ${claude_output:0:500}"
 
-    local action
+    local json_block action
+    json_block=$(_extract_review_json "$claude_output")
     set +e
-    action=$(echo "$claude_output" | jq -r '.action // empty' 2>/dev/null || echo "")
+    action=$(printf '%s' "$json_block" | jq -r '.action // empty' 2>/dev/null || echo "")
     set -e
 
     case "$action" in
@@ -122,7 +173,7 @@ run_post_impl_review() {
             ;;
         concerns)
             log "Post-implementation review: concerns found"
-            POST_IMPL_REVIEW_CONCERNS=$(echo "$claude_output" | jq -r '.concerns[]' 2>/dev/null | sed 's/^/- /')
+            POST_IMPL_REVIEW_CONCERNS=$(printf '%s' "$json_block" | jq -r '.concerns[]' 2>/dev/null | sed 's/^/- /')
             return 1
             ;;
         *)

--- a/tests/test_review_gates.bats
+++ b/tests/test_review_gates.bats
@@ -262,3 +262,112 @@ _source_review_gates() {
     triage_count=$(grep -c 'AGENT_ALLOWED_TOOLS_TRIAGE' "${LIB_DIR}/review-gates.sh")
     [ "$triage_count" -ge 2 ]
 }
+
+# ═══════════════════════════════════════════════════════════════
+# JSON extraction — narrative preamble / fence / postamble
+# Regression guard for Webber #59: Claude ignored "JSON only" rule and
+# wrote a verification summary before the final JSON object. The
+# previous parser passed the full text to jq and failed to extract
+# .action, flagging a clean "approved" review as unparseable.
+# ═══════════════════════════════════════════════════════════════
+
+@test "REGRESSION Gate A: approved JSON with narrative preamble (Webber #59)" {
+    export AGENT_ADVERSARIAL_PLAN_REVIEW="true"
+    export AGENT_PLAN_CONTENT="Test plan"
+    _source_review_gates
+
+    # Claude ignored "JSON only" and narrated its verification before the JSON.
+    # This is the exact failure shape seen on Webber issue #59.
+    run_claude() {
+        echo '{"result":"I verified all claims.\n\n**Verified:**\n- Line 302 confirmed\n- Line 3732 confirmed\n\n**No issues found.**\n\n{\"action\": \"approved\"}"}'
+    }
+
+    run run_adversarial_plan_review
+    assert_success
+}
+
+@test "REGRESSION Gate A: approved JSON wrapped in markdown code fence" {
+    export AGENT_ADVERSARIAL_PLAN_REVIEW="true"
+    export AGENT_PLAN_CONTENT="Test plan"
+    _source_review_gates
+
+    run_claude() {
+        echo '{"result":"```json\n{\"action\": \"approved\"}\n```"}'
+    }
+
+    run run_adversarial_plan_review
+    assert_success
+}
+
+@test "REGRESSION Gate A: approved JSON with trailing explanation" {
+    export AGENT_ADVERSARIAL_PLAN_REVIEW="true"
+    export AGENT_PLAN_CONTENT="Test plan"
+    _source_review_gates
+
+    run_claude() {
+        echo '{"result":"{\"action\": \"approved\"}\n\nLet me know if you need anything else."}'
+    }
+
+    run run_adversarial_plan_review
+    assert_success
+}
+
+@test "REGRESSION Gate A: multiple JSON-looking objects, last one is authoritative" {
+    export AGENT_ADVERSARIAL_PLAN_REVIEW="true"
+    export AGENT_PLAN_CONTENT="Test plan"
+    _source_review_gates
+
+    # Claude might show an example object earlier in the narrative, then
+    # the real answer at the end. The last top-level {...} wins.
+    run_claude() {
+        echo '{"result":"For example, a flagging response might look like {\"action\": \"needs_clarification\"}. But here my decision is:\n\n{\"action\": \"approved\"}"}'
+    }
+
+    run run_adversarial_plan_review
+    assert_success
+}
+
+@test "REGRESSION Gate A: corrected JSON with narrative preamble preserves revised_plan" {
+    export AGENT_ADVERSARIAL_PLAN_REVIEW="true"
+    export AGENT_PLAN_CONTENT="Plan using metric A"
+    create_mock "gh" ""
+    _source_review_gates
+
+    run_claude() {
+        echo '{"result":"After reviewing, I found the plan used the wrong metric.\n\n{\"action\": \"corrected\", \"corrections\": [\"Changed metric A to metric B\"], \"revised_plan\": \"Plan using metric B\"}"}'
+    }
+
+    run_adversarial_plan_review
+    assert_equal "$AGENT_PLAN_CONTENT" "Plan using metric B"
+}
+
+@test "REGRESSION Gate B: concerns JSON with narrative preamble sets POST_IMPL_REVIEW_CONCERNS" {
+    export AGENT_POST_IMPL_REVIEW="true"
+    _source_review_gates
+
+    run_claude() {
+        echo '{"result":"I reviewed the diff. Here are my findings:\n\n{\"action\": \"concerns\", \"concerns\": [\"Tests use simplified topology\", \"Missing edge case for empty queue\"]}"}'
+    }
+
+    run_post_impl_review || true
+    [[ "$POST_IMPL_REVIEW_CONCERNS" == *"simplified topology"* ]]
+    [[ "$POST_IMPL_REVIEW_CONCERNS" == *"empty queue"* ]]
+}
+
+@test "REGRESSION review-gates: truly garbage output still fails (no false positive)" {
+    export AGENT_ADVERSARIAL_PLAN_REVIEW="true"
+    export AGENT_PLAN_CONTENT="Test plan"
+    create_mock "gh" ""
+    _source_review_gates
+
+    # No JSON at all — should still hit the unparseable path and fail
+    run_claude() {
+        echo '{"result":"I cannot complete this review. No JSON output here."}'
+    }
+
+    run run_adversarial_plan_review
+    assert_failure
+    local calls
+    calls=$(get_mock_calls "gh")
+    [[ "$calls" == *"agent:failed"* ]]
+}


### PR DESCRIPTION
The review gate parsers passed the entire Claude response to `jq -r '.action // empty'`, which fails when Claude wraps the required JSON in a narrative preamble, a markdown code fence, or trailing explanation text. The fresh session running the adversarial review doesn't always follow the prompt's "JSON only" directive — especially when it has findings it wants to explain before delivering a verdict.

Observed on Webber issue #59: Gate A ran a clean review, verified every claim in the plan against the codebase, found no issues, and emitted `{"action": "approved"}` — but prefixed the JSON with an eleven-line "Verified claims" summary. The parser failed to extract `.action`, the case statement hit the wildcard, and the dispatcher flagged the issue as `agent:failed`. The review itself passed; only the parser failed.

Fix: add `_extract_review_json` helper that (1) tries direct jq parse for the cheap compliant-output path and (2) falls back to an awk walker that tracks brace depth and emits the last top-level `{...}` block. Both gates now route their jq lookups through the extracted block instead of the raw claude_output.

Limitation: the awk walker does not understand quoted string values, so a literal brace inside a JSON string field could fool the depth counter. The review gate schemas (action/concerns/questions/ corrections with scalar and string-array fields) don't produce such values in practice. Full JSON parsing would require python3, which is not in REQUIRED_TOOLS.

Tests: seven new REGRESSION cases covering the exact Webber #59 preamble shape, markdown-fence wrapping, trailing-text postamble, multiple JSON-looking objects (last wins), corrected-action preamble preserving revised_plan, Gate B concerns with preamble, and negative case (no JSON → still fails with agent:failed). Full BATS suite green (172/172).

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

## Testing

<!-- How was this tested? -->
- [ ] ShellCheck passes (`shellcheck scripts/*.sh scripts/lib/*.sh`)
- [ ] BATS tests pass (`./tests/bats/bin/bats tests/`)
- [ ] Manual verification (describe what you tested)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
