### PR TITLE
fix(bot): bot offline after reboot — systemd wiring, restart hardening, setup_hook

### DIFF
--- a/discord-bot/agent-dispatch-bot.service
+++ b/discord-bot/agent-dispatch-bot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Agent Dispatch Discord Bot
-After=network-online.target
-Wants=network-online.target
+StartLimitIntervalSec=300
+StartLimitBurst=5
 
 [Service]
 Type=simple

--- a/discord-bot/bot.py
+++ b/discord-bot/bot.py
@@ -265,9 +265,10 @@ async def handle_button_interaction(interaction: discord.Interaction) -> None:
     log.info("ACTION: %s on %s#%d by %s (id=%s)", action, repo, issue_number, interaction.user, interaction.user.id)
 
 
-def create_notify_handler(channel):
-    """Create an aiohttp handler that sends notifications to the given Discord channel."""
+def create_notify_handler(bot):
+    """Create an aiohttp handler that sends notifications via the bot's channel."""
     async def handle_notify(request: web.Request) -> web.Response:
+        channel = bot.get_channel(CHANNEL_ID)
         if channel is None:
             return web.Response(status=503, text="Channel not found")
 
@@ -287,16 +288,48 @@ def create_notify_handler(channel):
     return handle_notify
 
 
-async def start_http_server(channel) -> None:
-    """Start the local HTTP server for receiving dispatch notifications."""
+async def start_http_server(bot) -> web.AppRunner:
+    """Start the local HTTP server for receiving dispatch notifications.
+
+    Returns the AppRunner for cleanup on shutdown.
+    """
     app = web.Application()
-    handler = create_notify_handler(channel)
+    handler = create_notify_handler(bot)
     app.router.add_post("/notify", handler)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "127.0.0.1", BOT_PORT)
     await site.start()
     log.info("HTTP listener on 127.0.0.1:%d", BOT_PORT)
+    return runner
+
+
+class DispatchBot(commands.Bot):
+    """Discord bot with HTTP notification server."""
+
+    def __init__(self) -> None:
+        intents = discord.Intents.default()
+        super().__init__(command_prefix="!", intents=intents)
+        self._http_runner: web.AppRunner | None = None
+
+    async def setup_hook(self) -> None:
+        """Start the HTTP server once, before the gateway connects."""
+        self._http_runner = await start_http_server(self)
+
+    async def on_ready(self) -> None:
+        log.info("Bot ready: %s (guild %d)", self.user, GUILD_ID)
+        channel = self.get_channel(CHANNEL_ID)
+        if not channel:
+            log.error("Channel %d not found — bot may not have access", CHANNEL_ID)
+
+    async def on_interaction(self, interaction: discord.Interaction) -> None:
+        if interaction.type == discord.InteractionType.component:
+            await handle_button_interaction(interaction)
+
+    async def close(self) -> None:
+        if self._http_runner:
+            await self._http_runner.cleanup()
+        await super().close()
 
 
 def main() -> None:
@@ -311,23 +344,7 @@ def main() -> None:
         print("Error: AGENT_DISCORD_GUILD_ID is not set")
         raise SystemExit(1)
 
-    intents = discord.Intents.default()
-    bot = commands.Bot(command_prefix="!", intents=intents)
-
-    @bot.event
-    async def on_ready():
-        log.info("Bot ready: %s (guild %d)", bot.user, GUILD_ID)
-
-        channel = bot.get_channel(CHANNEL_ID)
-        if not channel:
-            log.error("Channel %d not found — bot may not have access", CHANNEL_ID)
-        await start_http_server(channel)
-
-    @bot.event
-    async def on_interaction(interaction: discord.Interaction):
-        if interaction.type == discord.InteractionType.component:
-            await handle_button_interaction(interaction)
-
+    bot = DispatchBot()
     bot.run(BOT_TOKEN, log_handler=logging.StreamHandler(), log_level=logging.INFO)
 
 

--- a/discord-bot/install.sh
+++ b/discord-bot/install.sh
@@ -38,6 +38,7 @@ sed "s|WORKING_DIR|${SCRIPT_DIR}|g; s|CONFIG_PATH|${CONFIG_PATH}|g" \
     "${SCRIPT_DIR}/agent-dispatch-bot.service" > "$SERVICE_FILE"
 
 systemctl --user daemon-reload
+systemctl --user disable "$SERVICE_NAME" 2>/dev/null || true
 systemctl --user enable "$SERVICE_NAME"
 
 echo ""
@@ -55,3 +56,9 @@ echo "  AGENT_DISCORD_GUILD_ID"
 echo "  AGENT_DISCORD_ALLOWED_USERS or AGENT_DISCORD_ALLOWED_ROLE"
 echo "  AGENT_DISPATCH_REPO (owner/repo format)"
 echo "  AGENT_NOTIFY_BACKEND=\"bot\""
+echo ""
+echo "For the bot to start at boot (without requiring login):"
+echo "  sudo loginctl enable-linger \$(whoami)"
+echo ""
+echo "Note: After enabling linger, 'sudo systemctl --user ...' won't work."
+echo "Use 'ssh <user>@localhost' or export XDG_RUNTIME_DIR=/run/user/\$(id -u)"

--- a/discord-bot/tests/test_http.py
+++ b/discord-bot/tests/test_http.py
@@ -14,8 +14,15 @@ def mock_channel():
 
 
 @pytest.fixture
-def handler(mock_channel):
-    return create_notify_handler(mock_channel)
+def mock_bot(mock_channel):
+    bot = MagicMock()
+    bot.get_channel = MagicMock(return_value=mock_channel)
+    return bot
+
+
+@pytest.fixture
+def handler(mock_bot):
+    return create_notify_handler(mock_bot)
 
 
 @pytest.fixture
@@ -74,8 +81,10 @@ class TestNotifyHandler:
             assert "org/repo" in button.custom_id
 
     @pytest.mark.asyncio
-    async def test_returns_503_when_channel_is_none(self, make_request):
-        handler = create_notify_handler(None)
+    async def test_returns_503_when_channel_not_found(self, make_request):
+        bot = MagicMock()
+        bot.get_channel = MagicMock(return_value=None)
+        handler = create_notify_handler(bot)
         request = make_request(VALID_PAYLOAD)
         response = await handler(request)
         assert response.status == 503


### PR DESCRIPTION
## Summary

Fixes the Discord bot not auto-starting after machine reboot, plus a latent port-bind bug on gateway reconnects.

- **Service file:** Remove no-op `network-online.target` (silently ignored by `systemd --user`), add `StartLimitIntervalSec=300`/`StartLimitBurst=5` in `[Unit]` to prevent hot-loop on config errors
- **install.sh:** Run `disable` before `enable` to sweep stale symlinks from prior installs with different `WantedBy` targets (root cause of the auto-start failure); print `loginctl enable-linger` recommendation
- **bot.py:** Move HTTP server startup from `on_ready` (fires on every gateway reconnect) to `setup_hook()` (runs once, discord.py 2.0+); lazy channel resolution via `bot.get_channel()` at request time; graceful `AppRunner` cleanup on shutdown

## Root Cause

The original install created a symlink in `multi-user.target.wants/` (a system target, inert in user systemd). When the service file was later fixed to `WantedBy=default.target`, `systemctl --user enable` saw it as "already enabled" and didn't move the symlink. After reboot, the service never started.

## Test plan

- [x] 71/71 pytest tests pass (including updated `test_http.py` fixtures)
- [x] ShellCheck clean on all scripts
- [x] 181/181 BATS tests pass
- [x] Bot verified running on affected machine (service active, port 8675 bound, gateway connected)
- [x] CI: ShellCheck + BATS status checks

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)