### PR TITLE
fix(dispatch): add missing set +e guard in handle_issue_reply

### DIFF
--- a/scripts/agent-dispatch.sh
+++ b/scripts/agent-dispatch.sh
@@ -313,11 +313,13 @@ handle_issue_reply() {
     claude_output=$(parse_claude_output "$result")
 
     local triage_json action
+    set +e
     triage_json=$(echo "$claude_output" | grep -oE '[{][^{}]*"action"[^{}]*[}]' | tail -1)
     if [ -z "$triage_json" ]; then
         triage_json="$claude_output"
     fi
     action=$(echo "$triage_json" | jq -r '.action // empty' 2>/dev/null || echo "")
+    set -e
 
     if [ "$action" = "ask_questions" ]; then
         local questions

--- a/tests/test_set_e_guards.bats
+++ b/tests/test_set_e_guards.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# Guard: every triage-JSON extraction site must be wrapped in set +e / set -e.
+# Without the guard, a grep match failure under set -euo pipefail kills the
+# script before the graceful fallback path can execute.
+
+load 'helpers/test_helper'
+
+# shellcheck disable=SC2154
+@test "REGRESSION v0.1.0: all triage-JSON extraction sites have set +e guard" {
+    local script="${SCRIPTS_DIR}/agent-dispatch.sh"
+
+    # Find all line numbers with the JSON extraction pattern
+    local extraction_lines
+    extraction_lines=$(grep -n 'grep -oE.*\[{].*action.*\[}]' "$script" | cut -d: -f1)
+
+    [ -n "$extraction_lines" ] || fail "No JSON extraction sites found — pattern may have changed"
+
+    local missing=()
+    for line_num in $extraction_lines; do
+        # Check that 'set +e' appears within 3 lines before the extraction
+        local start=$((line_num - 3))
+        [ "$start" -lt 1 ] && start=1
+        if ! sed -n "${start},${line_num}p" "$script" | grep -q 'set +e'; then
+            missing+=("line $line_num")
+        fi
+    done
+
+    [ ${#missing[@]} -eq 0 ] || fail "JSON extraction sites missing set +e guard: ${missing[*]}"
+}


### PR DESCRIPTION
## Summary

- Adds `set +e`/`set -e` guard around the triage-JSON extraction in `handle_issue_reply()`, matching the identical guard already present in `handle_new_issue()` and `handle_direct_implement()`
- Without this guard, `grep -oE` returning exit 1 (no match) under `set -euo pipefail` terminates the script before the graceful fallback path can execute
- Adds regression test (`test_set_e_guards.bats`) that structurally verifies all JSON extraction sites have the guard, preventing future drift

Closes #44

## Test plan

- [x] `shellcheck scripts/agent-dispatch.sh` passes clean
- [x] New regression test passes: `./tests/bats/bin/bats tests/test_set_e_guards.bats`
- [x] Full test suite (227 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)