### PR TITLE
chore: update visible-identity references to claude-pal-action

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/jnurre64/claude-agent-dispatch/tree/main/docs
+    url: https://github.com/jnurre64/claude-pal-action/tree/main/docs
     about: Check the docs before filing an issue

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img src=".github/icon.png" width="150" alt="Claude Agent Dispatch">
+  <img src=".github/icon.png" width="150" alt="Claude Pal Action">
 </p>
-<h1 align="center">claude-agent-dispatch</h1>
+<h1 align="center">claude-pal-action</h1>
 
 <p align="center">
-  <a href="https://github.com/jnurre64/claude-agent-dispatch/actions/workflows/ci.yml"><img src="https://github.com/jnurre64/claude-agent-dispatch/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/jnurre64/claude-agent-dispatch/releases/latest"><img src="https://img.shields.io/github/v/release/jnurre64/claude-agent-dispatch" alt="Latest Release"></a>
+  <a href="https://github.com/jnurre64/claude-pal-action/actions/workflows/ci.yml"><img src="https://github.com/jnurre64/claude-pal-action/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/jnurre64/claude-pal-action/releases/latest"><img src="https://img.shields.io/github/v/release/jnurre64/claude-pal-action" alt="Latest Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="License: MIT"></a>
 </p>
 
@@ -69,7 +69,7 @@ Built-in protections at every layer: circuit breaker (8 bot comments/hour), phas
 **Option A: Claude-assisted (recommended)**
 
 ```bash
-git clone https://github.com/jnurre64/claude-agent-dispatch.git ~/agent-infra
+git clone https://github.com/jnurre64/claude-pal-action.git ~/agent-infra
 cd ~/agent-infra
 claude  # then type: /setup
 ```
@@ -79,7 +79,7 @@ The `/setup` skill walks you through everything interactively.
 **Option B: Shell script**
 
 ```bash
-git clone https://github.com/jnurre64/claude-agent-dispatch.git ~/agent-infra
+git clone https://github.com/jnurre64/claude-pal-action.git ~/agent-infra
 cd ~/agent-infra
 ./scripts/setup.sh
 ```
@@ -138,12 +138,12 @@ The system adapts to any project through your CLAUDE.md (coding conventions), cu
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, testing, and how to submit changes. Bug reports and feature requests are welcome via [GitHub Issues](https://github.com/jnurre64/claude-agent-dispatch/issues).
+See [CONTRIBUTING.md](CONTRIBUTING.md) for conventions, testing, and how to submit changes. Bug reports and feature requests are welcome via [GitHub Issues](https://github.com/jnurre64/claude-pal-action/issues).
 
 ## Repository Structure
 
 ```
-claude-agent-dispatch/
+claude-pal-action/
 ├── scripts/
 │   ├── agent-dispatch.sh        # Main dispatch entry point
 │   ├── cleanup.sh               # Scheduled cleanup (branches, gists, logs)
@@ -178,7 +178,7 @@ claude-agent-dispatch/
 
 ## Disclaimer
 
-Claude Agent Dispatch is an independent, community-built open-source project. It is not affiliated with, endorsed by, or sponsored by Anthropic, PBC. "Claude" and "Claude Code" are trademarks of Anthropic. This project uses Claude Code as its underlying agent and references these trademarks solely to describe that functionality.
+Claude Pal Action is an independent, community-built open-source project. It is not affiliated with, endorsed by, or sponsored by Anthropic, PBC. "Claude" and "Claude Code" are trademarks of Anthropic. This project uses Claude Code as its underlying agent and references these trademarks solely to describe that functionality.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,7 +5,7 @@
 If you discover a security vulnerability in this project, please report it responsibly:
 
 1. **Do not** open a public issue for security vulnerabilities
-2. Open a [private security advisory](https://github.com/jnurre64/claude-agent-dispatch/security/advisories/new) on this repository
+2. Open a [private security advisory](https://github.com/jnurre64/claude-pal-action/security/advisories/new) on this repository
 3. Or contact the maintainer directly
 
 ## Security Considerations

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,7 +2,7 @@
 # shellcheck disable=SC1091  # Sourced files are resolved at runtime
 set -euo pipefail
 
-# ─── Interactive setup wizard for claude-agent-dispatch ──────────
+# ─── Interactive setup wizard for claude-pal-action ──────────
 # Alternative to the /setup Claude Code skill for users without Claude Code.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -158,7 +158,7 @@ if [ "$SETUP_MODE" = "2" ]; then
     {
         echo "# Upstream tracking for standalone agent-dispatch installation"
         echo "# Do not edit manually — managed by /update skill and setup.sh"
-        echo "repo: https://github.com/jnurre64/claude-agent-dispatch.git"
+        echo "repo: https://github.com/jnurre64/claude-pal-action.git"
         echo "version: $CURRENT_SHA"
         echo "synced_at: \"$(date -u '+%Y-%m-%dT%H:%M:%SZ')\""
         echo "checksums:"
@@ -357,7 +357,7 @@ echo ""
 if [ "$SETUP_MODE" = "1" ]; then
     echo "  7. Clone the upstream repo on the runner and copy config:"
     echo ""
-    echo -e "     ${CYAN}git clone https://github.com/jnurre64/claude-agent-dispatch.git ~/agent-infra${NC}"
+    echo -e "     ${CYAN}git clone https://github.com/jnurre64/claude-pal-action.git ~/agent-infra${NC}"
     echo -e "     ${CYAN}cp $CONFIG_FILE ~/agent-infra/config.env${NC}"
     echo ""
     echo "  8. Commit and push the workflow files to $TARGET_REPO"


### PR DESCRIPTION
Phase 2.5 of the rename: minimal PR updating README badges, SECURITY.md, setup.sh echoed text, and issue-template docs URL. Bulk doc sweep follows in a separate PR. See `docs/superpowers/specs/2026-04-18-rename-to-claude-pal-action-design.md`.