### PR TITLE
docs: move affiliation disclaimer to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 A reusable dispatch system for running [Claude Code](https://claude.com/claude-code) agents on GitHub issues — autonomously triaging, planning, implementing, and addressing PR review feedback, all orchestrated through GitHub Actions and a label-driven state machine.
 
+> **Independent, community-built project.** Not affiliated with, endorsed by, or sponsored by Anthropic, PBC. "Claude" and "Claude Code" are trademarks of Anthropic; this project uses Claude Code as its underlying agent and references these trademarks solely to describe that functionality.
+
 ## Features
 
 - **No third-party platform layers** — runs on the official Claude Code CLI and GitHub Actions, with no additional SaaS dependencies on top. Authentication uses either your Pro/Max subscription (individual use) or an Anthropic API key (required for team/commercial use) — see [authentication.md](docs/authentication.md).
@@ -174,10 +176,6 @@ claude-pal-action/
 ├── CLAUDE.md                    # Claude Code instructions for this repo
 └── docs/                        # Full documentation
 ```
-
-## Disclaimer
-
-Claude Pal Action is an independent, community-built open-source project. It is not affiliated with, endorsed by, or sponsored by Anthropic, PBC. "Claude" and "Claude Code" are trademarks of Anthropic. This project uses Claude Code as its underlying agent and references these trademarks solely to describe that functionality.
 
 ## License
 


### PR DESCRIPTION
## Summary

Moves the "not affiliated with Anthropic" disclaimer from the bottom of the README to just below the tagline, above the Features section. Also rewords it from an H2 section into a callout blockquote to make it read as framing rather than a heavy standalone section.

## Why

Trademark best-practice guidance calls for affiliation disclaimers on trademark-adjacent project names (claude-pal-action uses "Claude") to be "clear and conspicuous". Bottom-of-README placement functionally fails that test — on GitHub's repo view, only the top portion renders above the fold, so a visitor forms their "is this official?" impression long before they ever see the disclaimer.

Research summary (run via the `oss-health` skill against claude-pal):
- [README Best Practices — Tilburg Science Hub](https://www.tilburgsciencehub.com/topics/collaborate-share/share-your-work/content-creation/readme-best-practices/) — top placement recommended for project-status/affiliation disclaimers.
- [nextflow-io/trademark](https://github.com/nextflow-io/trademark/blob/master/README.md) — reference example.
- [Protecting Your Brand in Open Source — TermsFeed](https://www.termsfeed.com/blog/open-source-trademark/) — clear-and-conspicuous requirement for trademark-adjacent naming.

## Test plan

- [ ] CI (shellcheck) passes — no script changes so should be unaffected
- [ ] Rendered README shows disclaimer blockquote between the tagline and "## Features"
- [ ] No remaining `## Disclaimer` section lower in the file