### PR TITLE
fix(bots): repair deploy + observability after sandbox-pal rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ discord-bot/.venv/
 discord-bot/__pycache__/
 discord-bot/tests/__pycache__/
 discord-bot/.pytest_cache/
+slack-bot/.venv/
+slack-bot/__pycache__/
+slack-bot/tests/__pycache__/
+slack-bot/.pytest_cache/
 
 # Python packaging artifacts
 **/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- `discord-bot/install.sh` and `slack-bot/install.sh` now `cd` into their own directory before running `pip install`, so the editable `-e ../shared` requirement resolves correctly when the script is invoked from any cwd. Without this, `bash slack-bot/install.sh` from the repo root failed with `../shared is not a valid editable requirement`.
+- `discord-bot/bot.py` now configures the root logger via `logging.basicConfig(force=True)` in `_setup_logging()` before `bot.run`. Previously `bot.run(..., log_handler=StreamHandler(), log_level=INFO)` only configured discord.py's own loggers, leaving the `dispatch-bot` logger without a handler — every routing-decision INFO line and action handler log line was silently dropped, making it impossible to triage notification issues from `journalctl`.
+
 ### Changed
 - Repository renamed from `jnurre64/claude-pal-action` to `jnurre64/sandbox-pal-action` (2026-04-23). Old URL continues to redirect indefinitely. No version bump — rename is non-breaking. The rebrand also drops "Claude" from user-visible identifiers: workflow filenames (`dispatch-*.yml` → `sandbox-pal-*.yml`), concurrency group names (`claude-agent-*` → `sandbox-pal-*`), the internal dispatch script and directory (`scripts/agent-dispatch.sh` → `scripts/sandbox-pal-dispatch.sh`, `.agent-dispatch/` → `.sandbox-pal-dispatch/`), systemd service names, and notification footers. Motivated by upcoming multi-model support. See `docs/superpowers/plans/2026-04-23-rename-to-sandbox-pal-action.md`.
 - Repository renamed from `jnurre64/claude-agent-dispatch` to `jnurre64/claude-pal-action` (2026-04-18). Old URL continues to redirect indefinitely. No version bump — rename is non-breaking. See `docs/superpowers/specs/2026-04-18-rename-to-claude-pal-action-design.md`.

--- a/discord-bot/bot.py
+++ b/discord-bot/bot.py
@@ -273,6 +273,19 @@ class DispatchBot(commands.Bot):
         await super().close()
 
 
+def _setup_logging() -> None:
+    """Configure the root logger so app loggers (notify handler, action handlers)
+    actually emit. discord.py's `bot.run(..., log_handler=...)` only configures
+    discord.py's own loggers, leaving `dispatch-bot` without a handler — which
+    silently drops every routing-decision INFO line we depend on for triage.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        force=True,
+    )
+
+
 def main() -> None:
     """Bot entrypoint."""
     if not BOT_TOKEN:
@@ -285,8 +298,12 @@ def main() -> None:
         print("Error: AGENT_DISCORD_GUILD_ID is not set")
         raise SystemExit(1)
 
+    _setup_logging()
     bot = DispatchBot()
-    bot.run(BOT_TOKEN, log_handler=logging.StreamHandler(), log_level=logging.INFO)
+    # log_handler=None opts out of discord.py's auto-config so it inherits the
+    # root config from _setup_logging (otherwise discord.py adds its own handler
+    # and we get duplicate output for discord.* loggers).
+    bot.run(BOT_TOKEN, log_handler=None)
 
 
 if __name__ == "__main__":

--- a/discord-bot/install.sh
+++ b/discord-bot/install.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SERVICE_NAME="sandbox-pal-dispatch-bot"
 
+# Ensure relative requirements like '-e ../shared' resolve against this script's
+# directory rather than the caller's cwd.
+cd "$SCRIPT_DIR"
+
 echo "=== Sandbox Pal Dispatch Bot Install ==="
 
 # Determine config.env path (same logic as sandbox-pal-dispatch.sh)

--- a/discord-bot/tests/test_logging_setup.py
+++ b/discord-bot/tests/test_logging_setup.py
@@ -1,0 +1,51 @@
+"""Regression: dispatch-bot logger must have an effective handler.
+
+Bug: discord-bot/bot.py originally called
+    bot.run(BOT_TOKEN, log_handler=logging.StreamHandler(), log_level=logging.INFO)
+which configures only discord.py's own loggers via `discord.utils.setup_logging`.
+Application loggers (`logging.getLogger("dispatch-bot")`) had no handler attached,
+so every `log.info(...)` from the notify handler and action handlers was dropped
+silently. This made routing decisions invisible in journald.
+
+Fix: call `logging.basicConfig` in `_setup_logging()` before `bot.run`.
+"""
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def isolated_logging():
+    """Reset root logger handlers before/after the test so basicConfig actually runs.
+
+    `logging.basicConfig` is a no-op if root already has handlers, so without this
+    fixture pytest's own log capture handlers would mask the bug under test.
+    """
+    root = logging.getLogger()
+    saved_handlers = root.handlers[:]
+    saved_level = root.level
+    root.handlers.clear()
+    try:
+        yield
+    finally:
+        root.handlers.clear()
+        for h in saved_handlers:
+            root.addHandler(h)
+        root.setLevel(saved_level)
+
+
+def test_setup_logging_attaches_effective_handler_to_dispatch_bot_logger(isolated_logging):
+    import bot
+
+    bot._setup_logging()
+
+    log = logging.getLogger("dispatch-bot")
+    assert log.hasHandlers(), (
+        "dispatch-bot logger has no effective handler — INFO lines from notify "
+        "handler and action handlers will be silently dropped"
+    )
+    assert log.getEffectiveLevel() <= logging.INFO, (
+        "dispatch-bot effective log level is above INFO — routing decision lines "
+        "will be filtered out"
+    )

--- a/slack-bot/install.sh
+++ b/slack-bot/install.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SERVICE_NAME="sandbox-pal-dispatch-slack"
 
+# Ensure relative requirements like '-e ../shared' resolve against this script's
+# directory rather than the caller's cwd.
+cd "$SCRIPT_DIR"
+
 echo "=== Sandbox Pal Dispatch Slack Bot Install ==="
 
 # Determine config.env path (same logic as sandbox-pal-dispatch.sh)

--- a/tests/test_bot_install.bats
+++ b/tests/test_bot_install.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# Guard: bot install scripts must change to their own directory before
+# `pip install`, or the editable `-e ../shared` requirement is resolved
+# against the caller's cwd and pip rejects it as "not a valid editable
+# requirement". Bug surfaced when re-running install.sh from outside the
+# bot directory; both Discord and Slack install scripts had the same defect.
+
+load 'helpers/test_helper'
+
+# shellcheck disable=SC2154
+@test "REGRESSION: discord-bot/install.sh cds into SCRIPT_DIR before pip install" {
+    local script="${TEST_ROOT}/../discord-bot/install.sh"
+    [ -f "$script" ] || fail "discord-bot/install.sh not found"
+
+    local pip_line
+    pip_line=$(grep -n 'pip" install' "$script" | head -1 | cut -d: -f1)
+    [ -n "$pip_line" ] || fail "no 'pip install' line found in discord-bot/install.sh"
+
+    if ! sed -n "1,${pip_line}p" "$script" | grep -qE '^[[:space:]]*cd[[:space:]]+"\$\{?SCRIPT_DIR\}?"'; then
+        fail "discord-bot/install.sh: missing 'cd \"\$SCRIPT_DIR\"' before pip install at line ${pip_line}"
+    fi
+}
+
+# shellcheck disable=SC2154
+@test "REGRESSION: slack-bot/install.sh cds into SCRIPT_DIR before pip install" {
+    local script="${TEST_ROOT}/../slack-bot/install.sh"
+    [ -f "$script" ] || fail "slack-bot/install.sh not found"
+
+    local pip_line
+    pip_line=$(grep -n 'pip" install' "$script" | head -1 | cut -d: -f1)
+    [ -n "$pip_line" ] || fail "no 'pip install' line found in slack-bot/install.sh"
+
+    if ! sed -n "1,${pip_line}p" "$script" | grep -qE '^[[:space:]]*cd[[:space:]]+"\$\{?SCRIPT_DIR\}?"'; then
+        fail "slack-bot/install.sh: missing 'cd \"\$SCRIPT_DIR\"' before pip install at line ${pip_line}"
+    fi
+}


### PR DESCRIPTION
Two related defects in the bot install/runtime path that surfaced while verifying per-repo channel routing (PR #52). Both regressions only manifest on a fresh deploy — the long-running daemons were unaffected until a restart, which is why they went unnoticed since the 2026-04-23 rename.

1. install.sh (both bots): pip install now resolves '-e ../shared' relative to the bot directory, not the caller's cwd. Previously `bash slack-bot/install.sh` from the repo root failed with "../shared is not a valid editable requirement". Added bats regression that asserts each install.sh `cd "$SCRIPT_DIR"` before the pip line.

2. discord-bot/bot.py: extracted `_setup_logging()` and call it before `bot.run`. discord.py's `bot.run(log_handler=...)` only configures discord.py's own loggers, leaving the `dispatch-bot` logger handler-less — every routing-decision INFO line was silently dropped, making `journalctl --user -u sandbox-pal-dispatch-bot` useless for triaging notification issues. Mirrors slack-bot's `logging.basicConfig` pattern. Pytest regression asserts the `dispatch-bot` logger has an effective handler at INFO level after `_setup_logging()`.

Also gitignores `slack-bot/.venv/` to match the existing discord-bot entries.

Verified end-to-end: rebuilt slack-bot venv via fixed install.sh from outside the bot directory, started the systemd unit, dispatched the 3-repo routing matrix via notify.sh, confirmed every routing decision is now logged on both bots.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

## Testing

<!-- How was this tested? -->
- [ ] ShellCheck passes (`shellcheck scripts/*.sh scripts/lib/*.sh`)
- [ ] BATS tests pass (`./tests/bats/bin/bats tests/`)
- [ ] Manual verification (describe what you tested)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
