### PR TITLE
chore(discord-bot): accept --config <path> in install.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- `discord-bot/install.sh` now accepts `--config <path>` for non-interactive use, matching `slack-bot/install.sh`. Previously the Discord installer always prompted via `read`, making scripted reinstalls fragile (callers had to feed an empty line via stdin to use the default). Both installers now share the same option-parsing block and reject unknown flags with exit 1.
+
 ### Fixed
 - `discord-bot/install.sh` and `slack-bot/install.sh` now `cd` into their own directory before running `pip install`, so the editable `-e ../shared` requirement resolves correctly when the script is invoked from any cwd. Without this, `bash slack-bot/install.sh` from the repo root failed with `../shared is not a valid editable requirement`.
 - `discord-bot/bot.py` now configures the root logger via `logging.basicConfig(force=True)` in `_setup_logging()` before `bot.run`. Previously `bot.run(..., log_handler=StreamHandler(), log_level=INFO)` only configured discord.py's own loggers, leaving the `dispatch-bot` logger without a handler — every routing-decision INFO line and action handler log line was silently dropped, making it impossible to triage notification issues from `journalctl`.

--- a/discord-bot/install.sh
+++ b/discord-bot/install.sh
@@ -11,9 +11,19 @@ cd "$SCRIPT_DIR"
 echo "=== Sandbox Pal Dispatch Bot Install ==="
 
 # Determine config.env path (same logic as sandbox-pal-dispatch.sh)
+# Accepts --config <path> for non-interactive use, falls back to interactive prompt
 DEFAULT_CONFIG="${AGENT_CONFIG:-${HOME}/agent-infra/config.env}"
-read -r -p "Path to config.env [${DEFAULT_CONFIG}]: " CONFIG_PATH
-CONFIG_PATH="${CONFIG_PATH:-$DEFAULT_CONFIG}"
+CONFIG_PATH=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --config) CONFIG_PATH="$2"; shift 2 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+if [ -z "$CONFIG_PATH" ]; then
+    read -r -p "Path to config.env [${DEFAULT_CONFIG}]: " CONFIG_PATH
+    CONFIG_PATH="${CONFIG_PATH:-$DEFAULT_CONFIG}"
+fi
 
 if [ ! -f "$CONFIG_PATH" ]; then
     echo "Warning: ${CONFIG_PATH} not found. Create it before starting the bot."

--- a/tests/test_bot_install.bats
+++ b/tests/test_bot_install.bats
@@ -34,3 +34,25 @@ load 'helpers/test_helper'
         fail "slack-bot/install.sh: missing 'cd \"\$SCRIPT_DIR\"' before pip install at line ${pip_line}"
     fi
 }
+
+# Both bot install scripts must accept `--config <path>` for non-interactive use.
+# Without it, scripted re-installs (after the rename, after CI, after this very
+# test) have to fall back to feeding `read` via stdin, which is fragile and
+# diverges between the two bots. Asserts the option-parsing block exists.
+# shellcheck disable=SC2154
+@test "discord-bot/install.sh accepts --config <path> non-interactively" {
+    local script="${TEST_ROOT}/../discord-bot/install.sh"
+    [ -f "$script" ] || fail "discord-bot/install.sh not found"
+
+    grep -qE '^[[:space:]]*--config\)' "$script" || \
+        fail "discord-bot/install.sh: missing '--config' case in option parser"
+}
+
+# shellcheck disable=SC2154
+@test "slack-bot/install.sh accepts --config <path> non-interactively" {
+    local script="${TEST_ROOT}/../slack-bot/install.sh"
+    [ -f "$script" ] || fail "slack-bot/install.sh not found"
+
+    grep -qE '^[[:space:]]*--config\)' "$script" || \
+        fail "slack-bot/install.sh: missing '--config' case in option parser"
+}


### PR DESCRIPTION
Bring discord-bot/install.sh's option parsing in line with slack-bot/install.sh, which has supported `--config <path>` for non-interactive use since the per-repo channel routing rollout. Without it, scripted reinstalls had to feed an empty line via stdin to use the default config path, which is fragile and diverged between the two bots.

Behavior is now symmetric:
- `--config <path>` is honored when provided
- absent flag falls back to the existing interactive prompt
- unknown flags exit 1 with a "Unknown option:" message

Adds a bats regression test asserting both installers grep-match the `--config)` case branch, alongside the existing `cd $SCRIPT_DIR` guard.

## Summary

<!-- Brief description of what this PR does -->

## Changes

<!-- List the key changes -->

## Testing

<!-- How was this tested? -->
- [ ] ShellCheck passes (`shellcheck scripts/*.sh scripts/lib/*.sh`)
- [ ] BATS tests pass (`./tests/bats/bin/bats tests/`)
- [ ] Manual verification (describe what you tested)

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->
