### PR TITLE
fix(discord-bot): omit View link button when notify url is empty

### DIFF
--- a/discord-bot/bot.py
+++ b/discord-bot/bot.py
@@ -75,7 +75,10 @@ def build_embed(
 def build_buttons(event_type: str, issue_number: int, url: str, repo: str) -> discord.ui.View:
     """Build interactive buttons for a notification message."""
     view = discord.ui.View(timeout=None)
-    view.add_item(discord.ui.Button(label="View", url=url, style=discord.ButtonStyle.link))
+    # Discord rejects link buttons with empty url (400 / 50035), so omit the
+    # View button when the caller didn't supply one.
+    if url:
+        view.add_item(discord.ui.Button(label="View", url=url, style=discord.ButtonStyle.link))
 
     if event_type in PLAN_EVENTS:
         view.add_item(discord.ui.Button(

--- a/discord-bot/tests/test_embeds.py
+++ b/discord-bot/tests/test_embeds.py
@@ -88,3 +88,18 @@ class TestBuildButtons:
         view = build_buttons("pr_created", 42, "https://example.com/pull/5", "org/repo")
         link_buttons = [c for c in view.children if c.url]
         assert any(b.url == "https://example.com/pull/5" for b in link_buttons)
+
+    def test_empty_url_omits_view_button(self):
+        # Discord's API rejects link buttons with empty url (400 / 50035), so
+        # build_buttons must skip the View button entirely in that case.
+        view = build_buttons("tests_passed", 42, "", "org/repo")
+        link_buttons = [c for c in view.children if getattr(c, "url", None)]
+        assert link_buttons == []
+
+    def test_empty_url_still_emits_action_buttons_for_plan(self):
+        view = build_buttons("plan_posted", 42, "", "org/repo")
+        labels = [child.label for child in view.children]
+        assert "View" not in labels
+        assert "Approve" in labels
+        assert "Request Changes" in labels
+        assert "Comment" in labels

--- a/discord-bot/tests/test_http.py
+++ b/discord-bot/tests/test_http.py
@@ -103,6 +103,19 @@ class TestNotifyHandler:
         response = await handler(request)
         assert response.status == 200
 
+    @pytest.mark.asyncio
+    async def test_empty_url_returns_200_and_sends(self, handler, mock_channel, make_request):
+        # A payload with url="" used to trigger Discord's 50035 rejection on the
+        # link button and bubble up as a 500. The handler should now succeed and
+        # the message should be sent without a View link.
+        request = make_request({**VALID_PAYLOAD, "url": ""})
+        response = await handler(request)
+        assert response.status == 200
+        mock_channel.send.assert_called_once()
+        view = mock_channel.send.call_args.kwargs["view"]
+        link_buttons = [c for c in view.children if getattr(c, "url", None)]
+        assert link_buttons == []
+
 
 class TestPerRepoChannelRouting:
     @pytest.mark.asyncio

--- a/docs/runner-update-plan-phase1.md
+++ b/docs/runner-update-plan-phase1.md
@@ -89,7 +89,7 @@ Check that:
 curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:8675/notify \
   -X POST \
   -H "Content-Type: application/json" \
-  -d '{"event_type":"test","title":"Runner update test","url":"","description":"Testing after Phase 1 update"}'
+  -d '{"event_type":"test","title":"Runner update test","url":"https://example.com","description":"Testing after Phase 1 update"}'
 ```
 
 Expected: HTTP status `200` (or `204`). If the bot is working, it will log the


### PR DESCRIPTION
## Summary

Fixes a 500 from the `/notify` HTTP listener when the payload's `url` is empty. Discord's API rejects link buttons with empty `url` (`400 / error 50035`), which surfaced through the bot as a server error to the caller.

## Changes

- `discord-bot/bot.py` — guard the View link button in `build_buttons()` on a non-empty `url`. Action buttons (Approve/Request Changes/Comment/Retry) still render for plan/retry events.
- `discord-bot/tests/test_embeds.py` — 2 new tests: empty url omits the View button; action buttons still emitted for `plan_posted`.
- `discord-bot/tests/test_http.py` — 1 new test: handler returns 200 (not 500) and sends a message without a link button when `url=""`.
- `docs/runner-update-plan-phase1.md` — Step 6 smoke-test payload uses `https://example.com` instead of an empty url.

## Testing
- [x] ShellCheck passes (`shellcheck scripts/*.sh scripts/lib/*.sh`)
- [x] BATS tests pass (`./tests/bats/bin/bats tests/`) — 266/266
- [x] Python tests pass (`pytest discord-bot/tests/`) — 84/84, including the 3 new regression tests
- [ ] Manual verification against a live bot — not yet performed; the integration test in `test_http.py` simulates the reproducer end-to-end through `create_notify_handler`, but a real curl against the running service is recommended before deploying.

## Related Issues

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)