### PR TITLE
docs(readme): add Notifications row to documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The system adapts to any project through your CLAUDE.md (coding conventions), cu
 | [FAQ](docs/faq.md) | Common questions about safety, privacy, costs, and usage |
 | [Configuration](docs/configuration.md) | All settings and options |
 | [Customization](docs/customization.md) | Prompts, tools, and project-specific setup |
+| [Notifications](docs/notifications.md) | Discord and Slack setup — bots, webhooks, per-repo channel routing |
 | [Operations](docs/operations.md) | Logs, monitoring, retrying failed issues |
 | [Bot Account](docs/bot-account.md) | Creating and configuring the bot GitHub account |
 | [Runners](docs/runners.md) | Self-hosted runner setup |


### PR DESCRIPTION
## Summary

Adds a Notifications row to the README documentation index, linking `docs/notifications.md`. This was the final outstanding item from #19 — the issue's first comment (2026-04-06) and addendum (2026-04-12, "Documentation update") explicitly required it, but it slipped through Phase 3.

## Changes

- `README.md`: insert one row in the Documentation table between Customization and Operations, pointing to `docs/notifications.md` with a brief description covering Discord, Slack, and per-repo channel routing.

## Testing

- [x] No code changed — docs only, no shell or BATS impact.
- [x] Verified `docs/notifications.md` exists and covers both Discord and Slack setup.
- [x] Visual check of the resulting markdown table.

## Related Issues

Closes #19