### PR TITLE
Document repository_dispatch as the programmatic on-ramp; breadcrumb for silent label skips (#75)

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -140,14 +140,14 @@ For each template:
 
 Ask the user where their target repo is cloned locally so you can write the files there. For standalone mode, this was already collected in Step 2.
 
-### Discord bot dispatch (optional)
+### Programmatic dispatch (optional)
 
-If the user has set up the Discord bot (see `docs/notifications.md`), also deploy the dispatch template:
+If any automation will trigger the agent while authenticated as the bot account -- the Discord bot (see `docs/notifications.md`), an orchestrator session, or scripts using the bot PAT -- also deploy the dispatch template:
 
 - **Reference mode:** `caller-dispatch.yml`
 - **Standalone mode:** `sandbox-pal-dispatch.yml` (from `templates/standalone/`)
 
-This template enables the Discord bot's Approve, Retry, Comment, and Request Changes actions to trigger agent workflows. It is only needed if the Discord bot is in use.
+This "Agent Dispatch (programmatic)" workflow is the official programmatic on-ramp: `repository_dispatch` with event types `agent-triage`, `agent-implement`, and `agent-reply`. Label events applied by the bot account are filtered by the anti-self-trigger guard, so bot-driven automation must use this path. The Discord bot's Approve, Retry, Comment, and Request Changes actions are one caller of it. See `docs/architecture.md`, "Programmatic Triggering (repository_dispatch)".
 
 ## Step 7: Guide Secret Setup
 

--- a/.claude/skills/setup/templates/caller-direct-implement.yml
+++ b/.claude/skills/setup/templates/caller-direct-implement.yml
@@ -14,3 +14,23 @@ jobs:
       bot_user: "{{BOT_USER}}"
     secrets:
       agent_pat: ${{ secrets.AGENT_PAT }}
+
+  # Breadcrumb: label events from the bot account are filtered by the
+  # anti-self-trigger guard above. Leave a comment explaining the skip so
+  # programmatic callers aren't debugging silence. Direct implement has no
+  # repository_dispatch event type — the label must come from a human account.
+  actor-filter-notice:
+    if: >-
+      github.event.label.name == 'agent:implement' &&
+      github.actor == '{{BOT_USER}}'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain the skipped label trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body 'The `agent:implement` label was applied by the bot account (`{{BOT_USER}}`), so the label-triggered agent workflow was intentionally skipped (anti-self-trigger guard). This trigger has no `repository_dispatch` event type — re-apply the label from a human account. Details: https://github.com/jnurre64/sandbox-pal-action/blob/main/docs/architecture.md#programmatic-triggering-repository_dispatch'

--- a/.claude/skills/setup/templates/caller-dispatch.yml
+++ b/.claude/skills/setup/templates/caller-dispatch.yml
@@ -1,4 +1,4 @@
-name: "Claude Agent: Discord Dispatch"
+name: "Agent Dispatch (programmatic)"
 
 on:
   repository_dispatch:

--- a/.claude/skills/setup/templates/caller-implement.yml
+++ b/.claude/skills/setup/templates/caller-implement.yml
@@ -14,3 +14,23 @@ jobs:
       bot_user: "{{BOT_USER}}"
     secrets:
       agent_pat: ${{ secrets.AGENT_PAT }}
+
+  # Breadcrumb: label events from the bot account are filtered by the
+  # anti-self-trigger guard above. Leave a comment explaining the skip so
+  # programmatic callers aren't debugging silence — they should use
+  # repository_dispatch (see "Agent Dispatch (programmatic)").
+  actor-filter-notice:
+    if: >-
+      github.event.label.name == 'agent:plan-approved' &&
+      github.actor == '{{BOT_USER}}'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain the skipped label trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body 'The `agent:plan-approved` label was applied by the bot account (`{{BOT_USER}}`), so the label-triggered agent workflow was intentionally skipped (anti-self-trigger guard). Automation running as the bot should trigger via `repository_dispatch` (event type `agent-implement`) instead — see https://github.com/jnurre64/sandbox-pal-action/blob/main/docs/architecture.md#programmatic-triggering-repository_dispatch'

--- a/.claude/skills/setup/templates/caller-triage.yml
+++ b/.claude/skills/setup/templates/caller-triage.yml
@@ -14,3 +14,23 @@ jobs:
       bot_user: "{{BOT_USER}}"
     secrets:
       agent_pat: ${{ secrets.AGENT_PAT }}
+
+  # Breadcrumb: label events from the bot account are filtered by the
+  # anti-self-trigger guard above. Leave a comment explaining the skip so
+  # programmatic callers aren't debugging silence — they should use
+  # repository_dispatch (see "Agent Dispatch (programmatic)").
+  actor-filter-notice:
+    if: >-
+      github.event.label.name == 'agent' &&
+      github.actor == '{{BOT_USER}}'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain the skipped label trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body 'The `agent` label was applied by the bot account (`{{BOT_USER}}`), so the label-triggered agent workflow was intentionally skipped (anti-self-trigger guard). Automation running as the bot should trigger via `repository_dispatch` instead — see https://github.com/jnurre64/sandbox-pal-action/blob/main/docs/architecture.md#programmatic-triggering-repository_dispatch'

--- a/.claude/skills/setup/templates/standalone/sandbox-pal-direct-implement.yml
+++ b/.claude/skills/setup/templates/standalone/sandbox-pal-direct-implement.yml
@@ -33,3 +33,23 @@ jobs:
             direct_implement \
             "${{ github.repository }}" \
             "${{ github.event.issue.number }}"
+
+  # Breadcrumb: label events from the bot account are filtered by the
+  # anti-self-trigger guard above. Leave a comment explaining the skip so
+  # programmatic callers aren't debugging silence. Direct implement has no
+  # repository_dispatch event type — the label must come from a human account.
+  actor-filter-notice:
+    if: >-
+      github.event.label.name == 'agent:implement' &&
+      github.actor == '{{BOT_USER}}'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain the skipped label trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body 'The `agent:implement` label was applied by the bot account (`{{BOT_USER}}`), so the label-triggered agent workflow was intentionally skipped (anti-self-trigger guard). This trigger has no `repository_dispatch` event type — re-apply the label from a human account. Details: https://github.com/jnurre64/sandbox-pal-action/blob/main/docs/architecture.md#programmatic-triggering-repository_dispatch'

--- a/.claude/skills/setup/templates/standalone/sandbox-pal-dispatch.yml
+++ b/.claude/skills/setup/templates/standalone/sandbox-pal-dispatch.yml
@@ -1,4 +1,4 @@
-name: "Claude Agent: Discord Dispatch"
+name: "Agent Dispatch (programmatic)"
 
 on:
   repository_dispatch:

--- a/.claude/skills/setup/templates/standalone/sandbox-pal-implement.yml
+++ b/.claude/skills/setup/templates/standalone/sandbox-pal-implement.yml
@@ -33,3 +33,23 @@ jobs:
             implement \
             "${{ github.repository }}" \
             "${{ github.event.issue.number }}"
+
+  # Breadcrumb: label events from the bot account are filtered by the
+  # anti-self-trigger guard above. Leave a comment explaining the skip so
+  # programmatic callers aren't debugging silence — they should use
+  # repository_dispatch (see "Agent Dispatch (programmatic)").
+  actor-filter-notice:
+    if: >-
+      github.event.label.name == 'agent:plan-approved' &&
+      github.actor == '{{BOT_USER}}'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain the skipped label trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body 'The `agent:plan-approved` label was applied by the bot account (`{{BOT_USER}}`), so the label-triggered agent workflow was intentionally skipped (anti-self-trigger guard). Automation running as the bot should trigger via `repository_dispatch` (event type `agent-implement`) instead — see https://github.com/jnurre64/sandbox-pal-action/blob/main/docs/architecture.md#programmatic-triggering-repository_dispatch'

--- a/.claude/skills/setup/templates/standalone/sandbox-pal-triage.yml
+++ b/.claude/skills/setup/templates/standalone/sandbox-pal-triage.yml
@@ -33,3 +33,23 @@ jobs:
             new_issue \
             "${{ github.repository }}" \
             "${{ github.event.issue.number }}"
+
+  # Breadcrumb: label events from the bot account are filtered by the
+  # anti-self-trigger guard above. Leave a comment explaining the skip so
+  # programmatic callers aren't debugging silence — they should use
+  # repository_dispatch (see "Agent Dispatch (programmatic)").
+  actor-filter-notice:
+    if: >-
+      github.event.label.name == 'agent' &&
+      github.actor == '{{BOT_USER}}'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Explain the skipped label trigger
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" \
+            --repo "${{ github.repository }}" \
+            --body 'The `agent` label was applied by the bot account (`{{BOT_USER}}`), so the label-triggered agent workflow was intentionally skipped (anti-self-trigger guard). Automation running as the bot should trigger via `repository_dispatch` instead — see https://github.com/jnurre64/sandbox-pal-action/blob/main/docs/architecture.md#programmatic-triggering-repository_dispatch'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Actor-filter breadcrumb (#75): the label caller templates (triage, implement, direct-implement; reference and standalone variants) now include an `actor-filter-notice` job that comments on the issue when a trigger label is applied by the bot account — previously the anti-self-trigger guard skipped the run with no feedback anywhere. The comment runs on `ubuntu-latest` with the default `GITHUB_TOKEN`, so it works even when the self-hosted runner is down and cannot re-trigger workflows.
+- `repository_dispatch` documented as the official programmatic on-ramp (#75): event types `agent-triage`/`agent-implement`/`agent-reply` and the `client_payload.issue_number` payload are now covered in `docs/architecture.md` ("Programmatic Triggering"), `docs/troubleshooting.md` (Actor Filter check), and the setup skill.
+
 ### Changed
+- Dispatch caller workflow renamed from "Claude Agent: Discord Dispatch" to "Agent Dispatch (programmatic)" (#75) — Discord is one caller of the `repository_dispatch` entry point, not its owner. Cosmetic `name:` change only; filenames and event types are unchanged, no migration needed for existing consumers.
 - `discord-bot/install.sh` now accepts `--config <path>` for non-interactive use, matching `slack-bot/install.sh`. Previously the Discord installer always prompted via `read`, making scripted reinstalls fragile (callers had to feed an empty line via stdin to use the default). Both installers now share the same option-parsing block and reject unknown flags with exit 1.
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,8 +109,35 @@ The system uses six reusable GitHub Actions workflows (`sandbox-pal-*.yml`) that
 | `issues.labeled` | `agent:implement` label added | `sandbox-pal-direct-implement.yml` | Label is `agent:implement`, actor != `your-bot` |
 | `pull_request_review.submitted` | Review with changes requested | `sandbox-pal-review.yml` | State is `changes_requested`, reviewer != `your-bot` |
 | `pull_request.closed` | merged agent PR | `sandbox-pal-post-merge.yml` | PR merged, PR author == `your-bot` |
+| `repository_dispatch` | `agent-triage` / `agent-implement` / `agent-reply` event type | `sandbox-pal-triage.yml` / `sandbox-pal-implement.yml` / `sandbox-pal-reply.yml` | Event type match only -- no actor filter (see below) |
 
 The actor/commenter/reviewer filters are critical -- without them, the bot's own actions would re-trigger workflows in an infinite loop.
+
+### Programmatic Triggering (`repository_dispatch`)
+
+The label filters above mean a trigger label applied *by the bot account itself* is ignored by design. Any automation that authenticates as the bot -- an orchestrator session, a chat bot, a script using the bot PAT -- must therefore not use labels to start work; its label events are filtered (repos set up with current templates leave a breadcrumb comment on the issue explaining the skip; older setups skip silently). The supported programmatic on-ramp is `repository_dispatch`.
+
+The dispatch caller workflow ("Agent Dispatch (programmatic)", installed by `/setup` as `caller-dispatch.yml` in reference mode or `sandbox-pal-dispatch.yml` in standalone mode) listens for three event types:
+
+| Event type | Phase | Human-path equivalent |
+|------------|-------|-----------------------|
+| `agent-triage` | Triage a new issue | Adding the `agent` label |
+| `agent-implement` | Implement an approved plan | Adding the `agent:plan-approved` label |
+| `agent-reply` | Process a reply on a waiting issue | Commenting on an `agent:needs-info` / `agent:plan-review` issue |
+
+The payload carries one field, `client_payload.issue_number`:
+
+```bash
+gh api repos/OWNER/REPO/dispatches \
+  -f event_type=agent-implement \
+  -F 'client_payload[issue_number]=42'
+```
+
+Notes:
+
+- Do **not** also apply the trigger label when firing `repository_dispatch`. The dispatch script manages state labels itself; a bot-applied trigger label only produces a skipped run and the breadcrumb comment.
+- The Discord bot is one caller of this entry point, not its owner -- anything holding the bot PAT can use it.
+- Direct implement (`agent:implement`) and post-merge cleanup have no dispatch event types today; those flows are label/PR-event only. The reusable workflows accept `issue_number`/`pr_number` input overrides if a consuming repo wants to wire up additional event types (see [configuration.md](configuration.md)).
 
 ## Two-Phase Dispatch
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,7 +51,17 @@ Your calling workflow must filter out the bot account to prevent self-triggering
 if: github.event.label.name == 'agent' && github.actor != 'my-bot'
 ```
 
-If the bot account is the one adding the label, the workflow will not fire. The `agent` label must be added by a human account.
+If the bot account is the one adding the label, the workflow will not fire. This is by design (the anti-self-trigger guard) and applies to *any* automation authenticated as the bot -- an orchestrator session, a chat bot, a script using the bot PAT. Repos set up with current templates leave a breadcrumb comment on the issue when this happens; older setups skip silently.
+
+Trigger labels must be added by a human account. The supported programmatic trigger is `repository_dispatch`, handled by the "Agent Dispatch (programmatic)" workflow:
+
+```bash
+gh api repos/OWNER/REPO/dispatches \
+  -f event_type=agent-triage \
+  -F 'client_payload[issue_number]=42'
+```
+
+Event types: `agent-triage` (= `agent` label), `agent-implement` (= `agent:plan-approved`), `agent-reply` (= human reply). See [architecture.md](architecture.md#programmatic-triggering-repository_dispatch) for the full contract.
 
 ### Check 3: Workflow Trigger Configuration
 


### PR DESCRIPTION
Closes #75.

## What changed

**Docs — `repository_dispatch` is now the documented programmatic on-ramp**
- `docs/architecture.md`: new "Programmatic Triggering (`repository_dispatch`)" section — event types (`agent-triage`/`agent-implement`/`agent-reply`), payload shape (`client_payload.issue_number`), a copy-paste `gh api` example, and an explicit note that programmatic callers must not apply trigger labels (the dispatch script manages state labels itself). Plus a row in the Event Triggers table.
- `docs/troubleshooting.md`: the "Actor Filter" check now explains the skip is by design for any automation on the bot PAT and shows the `repository_dispatch` command.
- Setup skill: the dispatch template step is reframed from "Discord bot dispatch" to "Programmatic dispatch" — the Discord bot is one caller, not the owner.

**Rename**
- Both dispatch templates' `name:` changed from "Claude Agent: Discord Dispatch" to "Agent Dispatch (programmatic)". Cosmetic; filenames and event types unchanged, no migration for existing consumers.

**Actor-filter breadcrumb**
- The three label-trigger caller templates (triage, implement, direct-implement; reference + standalone variants) gain an `actor-filter-notice` job with the inverted guard (`actor == bot`). It posts one issue comment explaining the intentional skip and pointing at `repository_dispatch`. It runs on `ubuntu-latest` with the default `GITHUB_TOKEN`, so it works even when the self-hosted runner is down and its comment cannot re-trigger workflows.

## Why

Label triggers applied by the bot account are filtered by the anti-self-trigger guard — correctly, but silently. In FingerWizard (2026-08-16) this cost real debugging time: three workflows skipped with no feedback, and the working `repository_dispatch` path was documented only as the Discord bot's entry point.

## Testing

- ShellCheck: pass (no script changes)
- BATS: 346/346 pass
- All 16 setup templates parse as valid YAML (including the new `actor-filter-notice` jobs)

Deliberately out of scope: no `repository_dispatch` event type for direct implement or post-merge (documented as label/PR-event only; the reusable workflows already accept number overrides if a consumer wants to wire those up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)