### PR TITLE
docs: model-tier guidance for AGENT_MODEL overrides

### DIFF
--- a/config.defaults.env.example
+++ b/config.defaults.env.example
@@ -99,6 +99,10 @@ AGENT_ALLOWED_TOOLS_IMPLEMENT="${AGENT_ALLOWED_TOOLS_IMPLEMENT:-Read,Edit,Write,
 # Per-workflow model overrides. Empty falls back to AGENT_MODEL, then CLI default.
 # Useful for picking a faster/cheaper model for read-only review phases while
 # keeping a stronger model for implementation (or vice versa).
+# Guidance: all-defaults (Opus everywhere) is the recommended baseline; reserve
+# frontier-tier pins (e.g. claude-fable-5, ~2x Opus pricing) for at most the
+# adversarial plan review — the read-mostly slot where extra judgment prevents
+# the expensive implement/review cycle. See docs/configuration.md#agent_model.
 # AGENT_MODEL_TRIAGE="${AGENT_MODEL_TRIAGE:-}"           # triage, reply, validate
 # AGENT_MODEL_IMPLEMENT="${AGENT_MODEL_IMPLEMENT:-}"         # implementation session
 # AGENT_MODEL_REVIEW="${AGENT_MODEL_REVIEW:-}"            # PR review session

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,30 @@ Timeout in seconds before the dispatch script kills a stuck `claude -p` process.
 AGENT_TIMEOUT=3600   # 1 hour
 ```
 
+### AGENT_MODEL
+
+The Claude model for agent sessions, plus per-workflow overrides. Everything empty (the default) runs the CLI default model — currently Opus — for every step.
+
+| Key | Default | Type |
+|-----|---------|------|
+| `AGENT_MODEL` | *(empty, CLI default)* | model name |
+| `AGENT_MODEL_TRIAGE` / `_IMPLEMENT` / `_REVIEW` / `_ADVERSARIAL_PLAN` / `_POST_IMPL_REVIEW` / `_POST_IMPL_RETRY` / `_TEST_FIX` / `_CLEANUP` | *(empty, falls back to `AGENT_MODEL`)* | model name |
+
+**Model-tier guidance.** The all-defaults configuration is the recommended baseline — Opus-tier models handle planning, implementation, and adversarial review well. Pinning a frontier-tier model (e.g. `claude-fable-5`, roughly 2× Opus pricing) across several pipeline steps multiplies cost per issue with little quality gain when a human or a stronger orchestrator session already gates plans and merges: in one deployment, three frontier sessions per issue consumed the bulk of the model budget while duplicating the orchestrator's own plan review. This mirrors Anthropic's multi-agent guidance — put the strongest model where judgment density is highest (orchestration, plan gating, synthesis) and run volume work on the default tier.
+
+If you escalate a single slot, `AGENT_MODEL_ADVERSARIAL_PLAN` is the highest-leverage pin: the plan review is read-mostly (cheap in tokens) and catches flaws before the expensive implement/review cycle, similar to the API's advisor-tool pattern (a cheaper executor consulting a stronger model for plan-level judgment). Cheap/fast models (`haiku`) fit `AGENT_MODEL_CLEANUP` and other bookkeeping steps.
+
+```bash
+# Recommended baseline — CLI default everywhere
+# (all AGENT_MODEL_* unset)
+
+# Escalate only the plan review, keep everything else on the default
+AGENT_MODEL_ADVERSARIAL_PLAN="claude-fable-5"
+
+# Bookkeeping on a cheap model
+AGENT_MODEL_CLEANUP="haiku"
+```
+
 ### AGENT_CIRCUIT_BREAKER_LIMIT
 
 Maximum number of bot comments allowed per hour on a single issue. If the limit is exceeded, the agent halts with `agent:failed` and posts a warning. This prevents infinite loops.

--- a/scripts/lib/defaults.sh
+++ b/scripts/lib/defaults.sh
@@ -80,12 +80,23 @@ AGENT_PROMPT_CLEANUP="${AGENT_PROMPT_CLEANUP:-}"
 AGENT_ALLOWED_TOOLS_CLEANUP="${AGENT_ALLOWED_TOOLS_CLEANUP:-Read,Edit,Write,Grep,Glob,Bash(git add:*),Bash(git commit:*),Bash(git rm:*),Bash(git status),Bash(git diff:*),Bash(git log:*),Bash(ls:*),Bash(cat:*),Bash(grep:*),Bash(find:*)}"
 
 # ─── Model configuration ────────────────────────────────────
-# Claude model to use (empty = use CLI default, currently Opus 4.6)
+# Claude model to use (empty = use CLI default, currently Opus)
 AGENT_MODEL="${AGENT_MODEL:-}"
 
 # Per-workflow model overrides (empty = fall back to AGENT_MODEL, then CLI default).
 # Use these to pick a faster/cheaper model for read-only review phases while
 # keeping a stronger model for implementation, or vice versa.
+#
+# Model-tier guidance: the all-defaults (Opus everywhere) configuration is the
+# recommended baseline. Pinning a frontier-tier model (e.g. claude-fable-5,
+# ~2x Opus pricing) across pipeline steps multiplies cost per issue with
+# little gain when a human or stronger orchestrator already gates plans and
+# merges — in one deployment, three frontier sessions per issue consumed the
+# bulk of the model budget while duplicating the orchestrator's own plan
+# review. If you escalate one slot, _ADVERSARIAL_PLAN is the highest-leverage
+# pin: it is read-mostly (cheap in tokens) and catches plan flaws before the
+# expensive implement/review cycle. Cheap/fast models fit _CLEANUP and other
+# bookkeeping steps.
 AGENT_MODEL_TRIAGE="${AGENT_MODEL_TRIAGE:-}"
 AGENT_MODEL_IMPLEMENT="${AGENT_MODEL_IMPLEMENT:-}"
 AGENT_MODEL_REVIEW="${AGENT_MODEL_REVIEW:-}"


### PR DESCRIPTION
Documents when per-workflow model pins are (and aren't) worth it, based on operating the pipeline on FingerWizard.

## What changed
- `scripts/lib/defaults.sh` — model-config comment now carries tiering guidance (all-defaults Opus baseline; frontier pins reserved for at most `_ADVERSARIAL_PLAN`; cheap models for `_CLEANUP`). Also fixes the stale "currently Opus 4.6" note.
- `config.defaults.env.example` — same guidance in short form, pointing at the docs.
- `docs/configuration.md` — new `### AGENT_MODEL` section (the overrides previously had no Optional Settings entry) with the guidance and example configs.

## Why
FingerWizard's Phase 1 ran three frontier (Fable) sessions per issue — triage/plan, adversarial plan review, post-impl review — and that consumed the bulk of the model budget while largely duplicating the orchestrator's own plan gate. Dropping the pipeline to the CLI default (Opus) matches Anthropic's published multi-agent guidance: strongest model on orchestration/plan-gating/synthesis, default tier on volume work; the adversarial plan review is the one read-mostly slot where a frontier pin pays for itself (analogous to the API's advisor-tool pattern).

Defaults are unchanged (everything empty = CLI default) — this is documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)